### PR TITLE
loosen requirements for StopEvent

### DIFF
--- a/llama-index-core/llama_index/core/workflow/__init__.py
+++ b/llama-index-core/llama_index/core/workflow/__init__.py
@@ -1,0 +1,18 @@
+from llama_index.core.workflow.decorators import step
+from llama_index.core.workflow.drawing import draw_all_possible_flows, draw_most_recent_execution
+from llama_index.core.workflow.errors import WorkflowRuntimeError, WorkflowTimeoutError, WorkflowValidationError
+from llama_index.core.workflow.events import Event, StartEvent, StopEvent
+from llama_index.core.workflow.workflow import Workflow
+
+__all__ = [
+    "Event",
+    "StartEvent",
+    "StopEvent",
+    "Workflow",
+    "WorkflowRuntimeError",
+    "WorkflowTimeoutError",
+    "WorkflowValidationError",
+    "draw_all_possible_flows",
+    "draw_most_recent_execution",
+    "step",
+]

--- a/llama-index-core/llama_index/core/workflow/__init__.py
+++ b/llama-index-core/llama_index/core/workflow/__init__.py
@@ -1,6 +1,13 @@
 from llama_index.core.workflow.decorators import step
-from llama_index.core.workflow.drawing import draw_all_possible_flows, draw_most_recent_execution
-from llama_index.core.workflow.errors import WorkflowRuntimeError, WorkflowTimeoutError, WorkflowValidationError
+from llama_index.core.workflow.drawing import (
+    draw_all_possible_flows,
+    draw_most_recent_execution,
+)
+from llama_index.core.workflow.errors import (
+    WorkflowRuntimeError,
+    WorkflowTimeoutError,
+    WorkflowValidationError,
+)
 from llama_index.core.workflow.events import Event, StartEvent, StopEvent
 from llama_index.core.workflow.workflow import Workflow
 

--- a/llama-index-core/llama_index/core/workflow/events.py
+++ b/llama-index-core/llama_index/core/workflow/events.py
@@ -1,5 +1,6 @@
 from collections import UserDict
 from dataclasses import dataclass, field
+from typing import Any
 
 
 class Event:
@@ -14,7 +15,7 @@ class StartEvent(UserDict, Event):
 class StopEvent(Event):
     """EndEvent signals the workflow to stop."""
 
-    msg: str = field(default="")
+    result: Any = field(default=None)
 
 
 EventType = type[Event]

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -69,7 +69,7 @@ class Workflow:
                     new_ev = await step(ev)
 
                     if self._verbose:
-                        print(f"Step {name} produced event {new_ev}")
+                        print(f"Step {name} produced event {type(new_ev).__name__}")
 
                     # handle the return value
                     if new_ev is None:
@@ -80,7 +80,7 @@ class Workflow:
 
                     if not isinstance(new_ev, Event):
                         warnings.warn(
-                            f"Step function {name} returned {new_ev} instead of an Event instance."
+                            f"Step function {name} returned {type(new_ev).__name__} instead of an Event instance."
                         )
                     else:
                         self.send_event(new_ev)
@@ -167,7 +167,7 @@ class Workflow:
         """Checks if the workflow is done."""
         return len(self._tasks) == 0
 
-    def get_result(self) -> str:
+    def get_result(self) -> Any:
         """Returns the result of the workflow."""
         return self._retval
 
@@ -179,7 +179,7 @@ class Workflow:
             t.cancel()
         # Remove any reference to the tasks
         self._tasks = set()
-        self._retval = ev.msg or None
+        self._retval = ev.result or None
 
     def _validate(self) -> None:
         """Validate the workflow to ensure it's well-formed."""
@@ -203,7 +203,7 @@ class Workflow:
                 if event_type == type(None):
                     # some events may not trigger other events
                     continue
-
+                
                 produced_events.add(event_type)
 
         # Check if all consumed events are produced

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -203,7 +203,7 @@ class Workflow:
                 if event_type == type(None):
                     # some events may not trigger other events
                     continue
-                
+
                 produced_events.add(event_type)
 
         # Check if all consumed events are produced

--- a/llama-index-core/tests/workflow/examples/rag.py
+++ b/llama-index-core/tests/workflow/examples/rag.py
@@ -97,7 +97,7 @@ class RAGWorkflow(Workflow):
             self.query = ev.get("query", "")
             return None
         elif isinstance(ev, QueryResult):
-            llm = Ollama(model="llama3.1:latest", request_timeout=120)
+            llm = Ollama(model="llama3.1:8b", request_timeout=120)
             summarizer = Refine(llm=llm, streaming=True, verbose=True)
             response = await summarizer.asynthesize(self.query, nodes=ev.nodes)
             return StopEvent(result=response)

--- a/llama-index-core/tests/workflow/examples/reflection.py
+++ b/llama-index-core/tests/workflow/examples/reflection.py
@@ -5,10 +5,14 @@ from typing import Union
 
 from pydantic import BaseModel
 
-from llama_index.core.workflow.events import Event, StartEvent, StopEvent
-from llama_index.core.workflow.workflow import Workflow
-from llama_index.core.workflow.decorators import step
 from llama_index.core.prompts import PromptTemplate
+from llama_index.core.workflow import (
+    Event,
+    StartEvent,
+    StopEvent,
+    Workflow,
+    step,
+)
 
 # pip install llama-index-llms-ollama
 from llama_index.llms.ollama import Ollama
@@ -74,7 +78,7 @@ class ReflectionWorkflow(Workflow):
         if isinstance(ev, StartEvent):
             passage = ev.get("passage")
             if not passage:
-                return StopEvent(msg="Please provide some text in input")
+                return StopEvent(result="Please provide some text in input")
             reflection_prompt = ""
         elif isinstance(ev, ValidationErrorEvent):
             passage = ev.passage
@@ -105,7 +109,7 @@ class ReflectionWorkflow(Workflow):
                 error=str(e), wrong_output=ev.output, passage=ev.passage
             )
 
-        return StopEvent(msg=ev.output)
+        return StopEvent(result=ev.output)
 
 
 async def main():
@@ -115,9 +119,6 @@ async def main():
         passage="I own two cars: a Fiat Panda with 45Hp and a Honda Civic with 330Hp."
     )
     print(ret)
-
-    w.draw_all_possible_flows()
-    w.draw_most_recent_execution()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR
- Makes the type for `StopEvent()` == `Any`
- Renames the attribute to `result` to make it a bit more clear that this is the result
- adds shortcut imports
- updates examples to use new imports
- updates the RAG example to show how streaming is supported

Things I'm unsure about
- do we want to maintain state between `run()` calls?
  - I was originally going to implement a chat engine with streaming
  - streaming outputs are difficult to write to state, we could probably provide some util to help do this?
- msg vs result, could go either way 
- Making the typing be `Any` kind of forces the user to remember what a workflow is returning. Not great UX