### PR TITLE
decorate free functions

### DIFF
--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -2,7 +2,12 @@ import inspect
 from typing import Any, Callable, List, Optional, TYPE_CHECKING, Type
 
 from llama_index.core.bridge.pydantic import BaseModel
-from .utils import validate_step_signature, get_param_types, get_return_types
+from .utils import (
+    validate_step_signature,
+    get_param_types,
+    get_return_types,
+    is_free_function,
+)
 from .errors import WorkflowValidationError
 
 
@@ -29,12 +34,8 @@ def step(workflow: Optional[Type["Workflow"]] = None):
         # This will raise providing a message with the specific validation failure
         validate_step_signature(func)
 
-        # Determine if this is a free function
-        name_toks = func.__qualname__.split(".")
-        is_free_func = len(name_toks) > 1 and name_toks[-2] == "<locals>"
-
-        # If this is a free function, add it to the workflow instance
-        if is_free_func:
+        # If this is a free function, call add_step() explicitly.
+        if is_free_function(func.__qualname__):
             if workflow is None:
                 msg = f"To decorate {func.__name__} please pass a workflow instance to the @step() decorator."
                 raise WorkflowValidationError(msg)

--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Callable, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, List, Optional, TYPE_CHECKING, Type
 
 from llama_index.core.bridge.pydantic import BaseModel
 from .utils import validate_step_signature, get_param_types, get_return_types
@@ -16,7 +16,7 @@ class StepConfig(BaseModel):
     return_types: List[Any]
 
 
-def step(workflow: Optional["Workflow"] = None):
+def step(workflow: Optional[Type["Workflow"]] = None):
     """Decorator used to mark methods and functions as workflow steps.
 
     Decorators are evaluated at import time, but we need to wait for

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -7,6 +7,7 @@ from typing import (
     Optional,
     Union,
     Callable,
+    Dict,
     get_type_hints,
 )
 
@@ -54,7 +55,7 @@ def validate_step_signature(fn: Callable) -> None:
         raise WorkflowValidationError(msg)
 
 
-def get_steps_from_class(_class: object) -> dict:
+def get_steps_from_class(_class: object) -> Dict[str, Callable]:
     """Given a class, return the list of its methods that were defined as steps."""
     step_methods = {}
     all_methods = inspect.getmembers(_class, predicate=inspect.ismethod)

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -68,6 +68,19 @@ def get_steps_from_class(_class: object) -> Dict[str, Callable]:
     return step_methods
 
 
+def get_steps_from_instance(workflow: object) -> Dict[str, Callable]:
+    """Given a workflow instance, return the list of its methods that were defined as steps."""
+    step_methods = {}
+    all_methods = inspect.getmembers(workflow, predicate=inspect.ismethod)
+
+    for name, method in all_methods:
+        print(name, hasattr(method, "__step_config"))
+        if hasattr(method, "__step_config"):
+            step_methods[name] = method
+
+    return step_methods
+
+
 def get_param_types(param: inspect.Parameter) -> List[object]:
     """Extract the types of a parameter. Handles Union and Optional types."""
     typ = param.annotation

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -61,7 +61,6 @@ def get_steps_from_class(_class: object) -> Dict[str, Callable]:
     all_methods = inspect.getmembers(_class, predicate=inspect.isfunction)
 
     for name, method in all_methods:
-        print(name, hasattr(method, "__step_config"))
         if hasattr(method, "__step_config"):
             step_methods[name] = method
 
@@ -74,7 +73,6 @@ def get_steps_from_instance(workflow: object) -> Dict[str, Callable]:
     all_methods = inspect.getmembers(workflow, predicate=inspect.ismethod)
 
     for name, method in all_methods:
-        print(name, hasattr(method, "__step_config"))
         if hasattr(method, "__step_config"):
             step_methods[name] = method
 

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -58,9 +58,10 @@ def validate_step_signature(fn: Callable) -> None:
 def get_steps_from_class(_class: object) -> Dict[str, Callable]:
     """Given a class, return the list of its methods that were defined as steps."""
     step_methods = {}
-    all_methods = inspect.getmembers(_class, predicate=inspect.ismethod)
+    all_methods = inspect.getmembers(_class, predicate=inspect.isfunction)
 
     for name, method in all_methods:
+        print(name, hasattr(method, "__step_config"))
         if hasattr(method, "__step_config"):
             step_methods[name] = method
 

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -92,3 +92,23 @@ def get_return_types(func: Callable) -> List[object]:
         return [t for t in get_args(return_hint) if t is not type(None)]
     else:
         return [return_hint]
+
+
+def is_free_function(qualname: str):
+    """Determines whether a certain qualified name points to a free function.
+
+    The strategy should be able to spot nested functions, for details see PEP-3155.
+    """
+    if not qualname:
+        msg = "The qualified name cannot be empty"
+        raise ValueError(msg)
+
+    toks = qualname.split(".")
+    if len(toks) == 1:
+        # e.g. `my_function`
+        return True
+    elif "<locals>" not in toks:
+        # e.g. `MyClass.my_method`
+        return False
+    else:
+        return toks[-2] == "<locals>"

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -28,13 +28,22 @@ class Workflow:
         self._step_flags: Dict[str, asyncio.Event] = {}
         self._accepted_events: List[Tuple[str, str]] = []
         self._retval: Any = None
+        self._step_functions: Dict[str, Callable] = {}
+
+    def add_step(self, func: Callable) -> None:
+        """Adds a free function as step for this workflow instance."""
+        self._step_functions[func.__name__] = func
+
+    def _get_steps(self) -> Dict[str, Callable]:
+        """Returns all the steps, whether defined as methods or free functions."""
+        return {**get_steps_from_class(self), **self._step_functions}
 
     def _start(self, stepwise: bool = False) -> None:
         """Sets up the queues and tasks for each declared step.
 
         This method also launches each step as an async task.
         """
-        for name, step_func in get_steps_from_class(self).items():
+        for name, step_func in self._get_steps().items():
             self._queues[name] = asyncio.Queue()
             self._step_flags[name] = asyncio.Event()
             step_config: Optional[StepConfig] = getattr(

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -11,6 +11,8 @@ from .errors import WorkflowRuntimeError, WorkflowTimeoutError, WorkflowValidati
 
 
 class Workflow:
+    _step_functions: Dict[str, Callable] = {}
+
     def __init__(
         self,
         timeout: int = 10,
@@ -28,11 +30,11 @@ class Workflow:
         self._step_flags: Dict[str, asyncio.Event] = {}
         self._accepted_events: List[Tuple[str, str]] = []
         self._retval: Any = None
-        self._step_functions: Dict[str, Callable] = {}
 
-    def add_step(self, func: Callable) -> None:
+    @classmethod
+    def add_step(cls, func: Callable) -> None:
         """Adds a free function as step for this workflow instance."""
-        self._step_functions[func.__name__] = func
+        cls._step_functions[func.__name__] = func
 
     def _get_steps(self) -> Dict[str, Callable]:
         """Returns all the steps, whether defined as methods or free functions."""

--- a/llama-index-core/tests/workflow/conftest.py
+++ b/llama-index-core/tests/workflow/conftest.py
@@ -28,7 +28,7 @@ class DummyWorkflow(Workflow):
 
     @step()
     async def end_step(self, ev: LastEvent) -> StopEvent:
-        return StopEvent(msg="Workflow completed")
+        return StopEvent(result="Workflow completed")
 
 
 @pytest.fixture()

--- a/llama-index-core/tests/workflow/test_decorator.py
+++ b/llama-index-core/tests/workflow/test_decorator.py
@@ -12,7 +12,7 @@ def test_decorated_config(workflow):
     def f(self, ev: Event) -> Event:
         return Event()
 
-    res = step(workflow=workflow)(f)
+    res = step(workflow=workflow.__class__)(f)
     config = getattr(res, "__step_config")
     assert config.accepted_events == [Event]
     assert config.event_name == "ev"

--- a/llama-index-core/tests/workflow/test_decorator.py
+++ b/llama-index-core/tests/workflow/test_decorator.py
@@ -5,6 +5,7 @@ import pytest
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import Event
 from llama_index.core.workflow.errors import WorkflowValidationError
+from llama_index.core.workflow.workflow import Workflow
 
 
 def test_decorated_config(workflow):
@@ -26,12 +27,15 @@ def test_decorate_wrong_signature():
         step()(f)
 
 
-def test_decorate_free_function(workflow):
-    @step(workflow=workflow)
+def test_decorate_free_function():
+    class TestWorkflow(Workflow):
+        pass
+
+    @step(workflow=TestWorkflow)
     def f(ev: Event) -> Event:
         return Event()
 
-    assert workflow._step_functions == {"f": f}
+    assert TestWorkflow._step_functions == {"f": f}
 
 
 def test_decorate_free_function_wrong_decorator():

--- a/llama-index-core/tests/workflow/test_utils.py
+++ b/llama-index-core/tests/workflow/test_utils.py
@@ -120,7 +120,7 @@ def test_get_steps_from_class():
         def not_a_step(self):
             pass
 
-    steps = get_steps_from_class(Test())
+    steps = get_steps_from_class(Test)
     assert len(steps)
     assert "my_method" in steps
 

--- a/llama-index-core/tests/workflow/test_utils.py
+++ b/llama-index-core/tests/workflow/test_utils.py
@@ -11,6 +11,7 @@ from llama_index.core.workflow.utils import (
     get_steps_from_class,
     get_param_types,
     get_return_types,
+    is_free_function,
 )
 
 
@@ -180,3 +181,10 @@ def test_get_return_types_list():
         return [""]
 
     assert get_return_types(f) == [List[str]]
+
+
+def test_is_free_function():
+    assert is_free_function("my_function") is True
+    assert is_free_function("MyClass.my_method") is False
+    assert is_free_function("some_function.<locals>.my_function") is True
+    assert is_free_function("some_function.<locals>.MyClass.my_function") is False

--- a/llama-index-core/tests/workflow/test_utils.py
+++ b/llama-index-core/tests/workflow/test_utils.py
@@ -9,6 +9,7 @@ from llama_index.core.workflow.events import Event, StartEvent, StopEvent
 from llama_index.core.workflow.utils import (
     validate_step_signature,
     get_steps_from_class,
+    get_steps_from_instance,
     get_param_types,
     get_return_types,
     is_free_function,
@@ -107,7 +108,7 @@ def test_validate_step_signature_too_many_params():
         validate_step_signature(f2)
 
 
-def test_get_steps_from_class():
+def test_get_steps_from():
     class Test:
         @step()
         def start(self, start: StartEvent) -> TestEvent:
@@ -121,6 +122,10 @@ def test_get_steps_from_class():
             pass
 
     steps = get_steps_from_class(Test)
+    assert len(steps)
+    assert "my_method" in steps
+
+    steps = get_steps_from_instance(Test())
     assert len(steps)
     assert "my_method" in steps
 

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -57,7 +57,7 @@ async def test_workflow_timeout():
         @step()
         async def slow_step(self, ev: StartEvent) -> StopEvent:
             await asyncio.sleep(5.0)
-            return StopEvent(msg="Done")
+            return StopEvent(result="Done")
 
     workflow = SlowWorkflow(timeout=1)
     with pytest.raises(WorkflowTimeoutError):
@@ -89,7 +89,7 @@ async def test_workflow_event_propagation():
         @step()
         async def step2(self, ev: TestEvent) -> StopEvent:
             events.append("step2")
-            return StopEvent(msg="Done")
+            return StopEvent(result="Done")
 
     workflow = EventTrackingWorkflow()
     await workflow.run()


### PR DESCRIPTION
# Description

Add the ability to decorate free functions. The requirement in order to do so is to pass a workflow class to the decorator like 
```
@step(workflow=RAGWorkflow)
def my_step(ev: Event) -> Event:
  return Event()
```

The decorator is just syntactic sugar for a new method in the workflow `RAGWorkflow.add_step(my_step)`.
The list of "free-function steps" is stored in the workflow class itself.