### PR TITLE
Pass global context to step functions

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -1,0 +1,4 @@
+from typing import Dict, Any
+
+# At this stage, Context is just a type alias for a dict with string keys.
+Context = Dict[str, Any]

--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -19,9 +19,10 @@ class StepConfig(BaseModel):
     accepted_events: List[Any]
     event_name: str
     return_types: List[Any]
+    pass_context: bool
 
 
-def step(workflow: Optional[Type["Workflow"]] = None):
+def step(workflow: Optional[Type["Workflow"]] = None, pass_context: bool = False):
     """Decorator used to mark methods and functions as workflow steps.
 
     Decorators are evaluated at import time, but we need to wait for
@@ -31,15 +32,15 @@ def step(workflow: Optional[Type["Workflow"]] = None):
     """
 
     def decorator(func: Callable) -> Callable:
-        # This will raise providing a message with the specific validation failure
-        validate_step_signature(func)
-
         # If this is a free function, call add_step() explicitly.
         if is_free_function(func.__qualname__):
             if workflow is None:
                 msg = f"To decorate {func.__name__} please pass a workflow instance to the @step() decorator."
                 raise WorkflowValidationError(msg)
             workflow.add_step(func)
+
+        # This will raise providing a message with the specific validation failure
+        validate_step_signature(func)
 
         # Get the function signature
         sig = inspect.signature(func)
@@ -59,6 +60,7 @@ def step(workflow: Optional[Type["Workflow"]] = None):
             accepted_events=event_types,
             event_name=event_name,
             return_types=return_types,
+            pass_context=pass_context,
         )
 
         return func

--- a/llama-index-core/tests/workflow/examples/rag.py
+++ b/llama-index-core/tests/workflow/examples/rag.py
@@ -17,6 +17,7 @@ from llama_index.core.workflow import (
     draw_all_possible_flows,
     draw_most_recent_execution,
 )
+from llama_index.core.workflow.context import Context
 
 # pip install llama-index-llms-ollama
 from llama_index.llms.ollama import Ollama
@@ -38,71 +39,69 @@ class QueryResult(Event):
 
 
 class RAGWorkflow(Workflow):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        # Shared state: to be refactored into a better workflow context manager
-        self.index: Any = None
-        self.query: str = ""
-
-    @step()
-    async def ingest(self, ev: StartEvent) -> Optional[StopEvent]:
+    @step(pass_context=True)
+    async def ingest(self, ctx: Context, ev: StartEvent) -> Optional[StopEvent]:
         dsname = ev.get("dataset")
         if not dsname:
             return None
 
         _, documents = download_llama_dataset(dsname, "./data")
-        self.index = VectorStoreIndex.from_documents(documents=documents)
+        ctx["INDEX"] = VectorStoreIndex.from_documents(documents=documents)
         return StopEvent(result=f"Indexed {len(documents)} documents.")
 
-    @step()
-    async def retrieve(self, ev: StartEvent) -> Optional[RetrieverEvent]:
+    @step(pass_context=True)
+    async def retrieve(self, ctx: Context, ev: StartEvent) -> Optional[RetrieverEvent]:
         query = ev.get("query")
         if not query:
             return None
 
         print(f"Query the database with: {query}")
-        if self.index is None:
+
+        index: Any = ctx.get("INDEX")
+        if index is None:
             print("Index is empty, load some documents before querying!")
             return None
 
         retriever = VectorIndexRetriever(
-            index=self.index,
+            index=index,
             similarity_top_k=10,
         )
         nodes = retriever.retrieve(query)
         print(f"Retrieved {len(nodes)} nodes.")
         return RetrieverEvent(nodes=nodes)
 
-    @step()
+    @step(pass_context=True)
     async def rerank(
-        self, ev: Union[RetrieverEvent, StartEvent]
+        self, ctx: Context, ev: Union[RetrieverEvent, StartEvent]
     ) -> Optional[QueryResult]:
         if isinstance(ev, StartEvent):
-            self.query = ev.get("query", "")
+            ctx["QUERY"] = ev.get("query", "")
             return None
         elif isinstance(ev, RetrieverEvent):
             ranker = LLMRerank(choice_batch_size=5, top_n=3)
-            new_nodes = ranker.postprocess_nodes(ev.nodes, query_str=self.query)
+            new_nodes = ranker.postprocess_nodes(ev.nodes, query_str=ctx.get("QUERY"))
             print(f"Reranked nodes to {len(new_nodes)}")
             return QueryResult(nodes=new_nodes)
         else:
             return None
 
-    @step()
-    async def synthesize(
-        self, ev: Union[QueryResult, StartEvent]
-    ) -> Optional[StopEvent]:
-        # Should never fallback, it'll get better once we have a proper context storage
-        if isinstance(ev, StartEvent):
-            self.query = ev.get("query", "")
-            return None
-        elif isinstance(ev, QueryResult):
-            llm = Ollama(model="llama3.1:8b", request_timeout=120)
-            summarizer = Refine(llm=llm, streaming=True, verbose=True)
-            response = await summarizer.asynthesize(self.query, nodes=ev.nodes)
-            return StopEvent(result=response)
-        else:
-            return None
+
+@step(workflow=RAGWorkflow, pass_context=True)
+async def synthesize(
+    ctx: Context, ev: Union[QueryResult, StartEvent]
+) -> Optional[StopEvent]:
+    # Should never fallback, it'll get better once we have a proper context storage
+    if isinstance(ev, StartEvent):
+        ctx["QUERY"] = ev.get("query", "")
+        return None
+    elif isinstance(ev, QueryResult):
+        llm = Ollama(model="llama3.1:8b", request_timeout=120)
+        summarizer = Refine(llm=llm, streaming=True, verbose=True)
+        query = ctx.get("QUERY", "")
+        response = await summarizer.asynthesize(query, nodes=ev.nodes)
+        return StopEvent(result=response)
+    else:
+        return None
 
 
 async def main() -> None:


### PR DESCRIPTION
- Introduce a `Context` type. For now it's just a dictionary, but goal is to give it whatever interface might be needed by steps to share and store state
- I'm not 100% sure of the UX (passing params to the decorator), I'll be happy to evaluate alternatives
- Changed the RAG example to use a `Context` object instead of `self.`. Also added a free function to the RAG example just for the sake of showing UX.