### PR TITLE
Logan/support non async

### DIFF
--- a/llama-index-core/tests/workflow/conftest.py
+++ b/llama-index-core/tests/workflow/conftest.py
@@ -28,7 +28,7 @@ class DummyWorkflow(Workflow):
 
     @step()
     async def end_step(self, ev: LastEvent) -> StopEvent:
-        return StopEvent(msg="Workflow completed")
+        return StopEvent(result="Workflow completed")
 
 
 @pytest.fixture()

--- a/llama-index-core/tests/workflow/examples/rag.py
+++ b/llama-index-core/tests/workflow/examples/rag.py
@@ -74,9 +74,7 @@ class RAGWorkflow(Workflow):
         return RetrieverEvent(nodes=nodes)
 
     @step()
-    async def rerank(
-        self, ev: Union[RetrieverEvent, StartEvent]
-    ) -> Optional[QueryResult]:
+    def rerank(self, ev: Union[RetrieverEvent, StartEvent]) -> Optional[QueryResult]:
         if isinstance(ev, StartEvent):
             self.query = ev.get("query", "")
             return None

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -94,3 +94,19 @@ async def test_workflow_event_propagation():
     workflow = EventTrackingWorkflow()
     await workflow.run()
     assert events == ["step1", "step2"]
+
+
+@pytest.mark.asyncio()
+async def test_sync_async_steps():
+    class SyncAsyncWorkflow(Workflow):
+        @step()
+        async def async_step(self, ev: StartEvent) -> TestEvent:
+            return TestEvent()
+
+        @step()
+        def sync_step(self, ev: TestEvent) -> StopEvent:
+            return StopEvent(result="Done")
+
+    workflow = SyncAsyncWorkflow()
+    await workflow.run()
+    assert workflow.is_done()

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -89,7 +89,7 @@ async def test_workflow_event_propagation():
         @step()
         async def step2(self, ev: TestEvent) -> StopEvent:
             events.append("step2")
-            return StopEvent(msg="Done")
+            return StopEvent(result="Done")
 
     workflow = EventTrackingWorkflow()
     await workflow.run()


### PR DESCRIPTION
This PR does two things
- prevents swallowing of exceptions (previously if a task raises an exception, you never see it, making debugging hard)
- allows steps to be both sync and async 