### PR TITLE
Improve signature validation

### DIFF
--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -1,11 +1,8 @@
-import inspect
 from typing import Any, Callable, List, Optional, TYPE_CHECKING, Type
 
 from llama_index.core.bridge.pydantic import BaseModel
 from .utils import (
     validate_step_signature,
-    get_param_types,
-    get_return_types,
     is_free_function,
 )
 from .errors import WorkflowValidationError
@@ -40,20 +37,7 @@ def step(workflow: Optional[Type["Workflow"]] = None, pass_context: bool = False
             workflow.add_step(func)
 
         # This will raise providing a message with the specific validation failure
-        validate_step_signature(func)
-
-        # Get the function signature
-        sig = inspect.signature(func)
-
-        for name, param in sig.parameters.items():
-            if name in ("self", "cls"):
-                continue
-
-            event_types = get_param_types(param)
-            event_name = name
-
-        # Extract return type
-        return_types = get_return_types(func)
+        event_name, event_types, return_types = validate_step_signature(func)
 
         # store the configuration in the function object
         func.__step_config = StepConfig(

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     List,
     Optional,
+    Tuple,
     Union,
     Callable,
     Dict,
@@ -16,12 +17,13 @@ from .events import Event
 from .errors import WorkflowValidationError
 
 
-def validate_step_signature(fn: Callable) -> None:
+def validate_step_signature(fn: Callable) -> Tuple[str, List[object], List[object]]:
     """Given a function, ensure the signature is compatible with a workflow step.
 
-    Two types of signatures are supported:
-        - self, ev: Event, for class methods
-        - ev: Event, for free functions
+    This function returns a tuple with:
+        - the name of the parameter delivering the event
+        - the list of event types in input
+        - the list of event types in output
     """
     sig = inspect.signature(fn)
 
@@ -30,6 +32,8 @@ def validate_step_signature(fn: Callable) -> None:
         msg = "Step signature must have at least one parameter"
         raise WorkflowValidationError(msg)
 
+    event_name = ""
+    event_types = []
     num_of_possible_events = 0
     for name, t in sig.parameters.items():
         if name in ("self", "cls"):
@@ -43,10 +47,7 @@ def validate_step_signature(fn: Callable) -> None:
         if t.annotation == Context:
             continue
 
-        if get_origin(t.annotation) in (Union, Optional):
-            event_types = get_args(t.annotation)
-        else:
-            event_types = [t.annotation]
+        event_types = _get_param_types(t)
 
         all_events = all(et == Event or issubclass(et, Event) for et in event_types)
 
@@ -54,12 +55,19 @@ def validate_step_signature(fn: Callable) -> None:
             msg = "Events in step signature parameters must be of type Event"
             raise WorkflowValidationError(msg)
 
+        # Number of events in the signature must be exactly one
         num_of_possible_events += 1
 
-    # Number of events in the signature must be exactly one
     if num_of_possible_events != 1:
         msg = f"Step signature must contain exactly one parameter of type Event but found {num_of_possible_events}."
         raise WorkflowValidationError(msg)
+
+    return_types = _get_return_types(fn)
+    if not return_types:
+        msg = f"Return types of workflows step functions must be annotated with their type."
+        raise WorkflowValidationError(msg)
+
+    return (event_name, event_types, return_types)
 
 
 def get_steps_from_class(_class: object) -> Dict[str, Callable]:
@@ -86,7 +94,7 @@ def get_steps_from_instance(workflow: object) -> Dict[str, Callable]:
     return step_methods
 
 
-def get_param_types(param: inspect.Parameter) -> List[object]:
+def _get_param_types(param: inspect.Parameter) -> List[object]:
     """Extract the types of a parameter. Handles Union and Optional types."""
     typ = param.annotation
     if typ is inspect.Parameter.empty:
@@ -96,16 +104,17 @@ def get_param_types(param: inspect.Parameter) -> List[object]:
     return [typ]
 
 
-def get_return_types(func: Callable) -> List[object]:
+def _get_return_types(func: Callable) -> List[object]:
     """Extract the return type hints from a function.
 
     Handles Union, Optional, and List types.
     """
     type_hints = get_type_hints(func)
-    return_hint = type_hints.get("return", [Any])
+    return_hint = type_hints.get("return")
+    if return_hint is None:
+        return []
 
     origin = get_origin(return_hint)
-
     if origin == Union:
         # Optional is Union[type, None] so it's covered here
         return [t for t in get_args(return_hint) if t is not type(None)]

--- a/llama-index-core/tests/workflow/test_utils.py
+++ b/llama-index-core/tests/workflow/test_utils.py
@@ -10,8 +10,8 @@ from llama_index.core.workflow.utils import (
     validate_step_signature,
     get_steps_from_class,
     get_steps_from_instance,
-    get_param_types,
-    get_return_types,
+    _get_param_types,
+    _get_return_types,
     is_free_function,
 )
 from llama_index.core.workflow.context import Context
@@ -26,35 +26,35 @@ class AnotherTestEvent(Event):
 
 
 def test_validate_step_signature_of_method():
-    def f(self, ev: TestEvent):
-        pass
+    def f(self, ev: TestEvent) -> TestEvent:
+        return TestEvent()
 
     validate_step_signature(f)
 
 
 def test_validate_step_signature_of_free_function():
-    def f(ev: TestEvent):
-        pass
+    def f(ev: TestEvent) -> TestEvent:
+        return TestEvent()
 
     validate_step_signature(f)
 
 
 def test_validate_step_signature_union():
-    def f(ev: Union[TestEvent, AnotherTestEvent]):
-        pass
+    def f(ev: Union[TestEvent, AnotherTestEvent]) -> TestEvent:
+        return TestEvent()
 
     validate_step_signature(f)
 
 
 def test_validate_step_signature_of_free_function_with_context():
-    def f(ctx: Context, ev: TestEvent):
-        pass
+    def f(ctx: Context, ev: TestEvent) -> TestEvent:
+        return TestEvent()
 
     validate_step_signature(f)
 
 
 def test_validate_step_signature_union_invalid():
-    def f(ev: Union[TestEvent, str]):
+    def f(ev: Union[TestEvent, str]) -> None:
         pass
 
     with pytest.raises(
@@ -65,7 +65,7 @@ def test_validate_step_signature_union_invalid():
 
 
 def test_validate_step_signature_no_params():
-    def f():
+    def f() -> None:
         pass
 
     with pytest.raises(
@@ -75,7 +75,7 @@ def test_validate_step_signature_no_params():
 
 
 def test_validate_step_signature_no_annotations():
-    def f(self, ev):
+    def f(self, ev) -> None:
         pass
 
     with pytest.raises(
@@ -86,7 +86,7 @@ def test_validate_step_signature_no_annotations():
 
 
 def test_validate_step_signature_wrong_annotations():
-    def f(self, ev: str):
+    def f(self, ev: str) -> None:
         pass
 
     with pytest.raises(
@@ -96,8 +96,19 @@ def test_validate_step_signature_wrong_annotations():
         validate_step_signature(f)
 
 
+def test_validate_step_signature_no_return_annotations():
+    def f(self, ev: TestEvent):
+        pass
+
+    with pytest.raises(
+        WorkflowValidationError,
+        match="Return types of workflows step functions must be annotated with their type",
+    ):
+        validate_step_signature(f)
+
+
 def test_validate_step_signature_no_events():
-    def f(self, ctx: Context):
+    def f(self, ctx: Context) -> None:
         pass
 
     with pytest.raises(
@@ -108,7 +119,7 @@ def test_validate_step_signature_no_events():
 
 
 def test_validate_step_signature_too_many_params():
-    def f1(self, ev: TestEvent, foo: TestEvent):
+    def f1(self, ev: TestEvent, foo: TestEvent) -> None:
         pass
 
     def f2(ev: TestEvent, foo: TestEvent):
@@ -154,7 +165,7 @@ def test_get_param_types():
         pass
 
     sig = inspect.signature(f)
-    res = get_param_types(sig.parameters["foo"])
+    res = _get_param_types(sig.parameters["foo"])
     assert len(res) == 1
     assert res[0] is str
 
@@ -164,7 +175,7 @@ def test_get_param_types_no_annotations():
         pass
 
     sig = inspect.signature(f)
-    res = get_param_types(sig.parameters["foo"])
+    res = _get_param_types(sig.parameters["foo"])
     assert len(res) == 1
     assert res[0] is Any
 
@@ -174,7 +185,7 @@ def test_get_param_types_union():
         pass
 
     sig = inspect.signature(f)
-    res = get_param_types(sig.parameters["foo"])
+    res = _get_param_types(sig.parameters["foo"])
     assert len(res) == 2
     assert res == [str, int]
 
@@ -183,28 +194,28 @@ def test_get_return_types():
     def f(foo: int) -> str:
         return ""
 
-    assert get_return_types(f) == [str]
+    assert _get_return_types(f) == [str]
 
 
 def test_get_return_types_union():
     def f(foo: int) -> Union[str, int]:
         return ""
 
-    assert get_return_types(f) == [str, int]
+    assert _get_return_types(f) == [str, int]
 
 
 def test_get_return_types_optional():
     def f(foo: int) -> Optional[str]:
         return ""
 
-    assert get_return_types(f) == [str]
+    assert _get_return_types(f) == [str]
 
 
 def test_get_return_types_list():
     def f(foo: int) -> List[str]:
         return [""]
 
-    assert get_return_types(f) == [List[str]]
+    assert _get_return_types(f) == [List[str]]
 
 
 def test_is_free_function():


### PR DESCRIPTION
# Description

- Raise when return type is not annotated to prevent cryptic errors (user feedback)
- Isolate `inspect` operations in the `utils` module
- Make some methods private

Overall, the code of the `step` decorator is much more simple now.
