### PR TITLE
[WIP] Initial Docs

### DIFF
--- a/docs/docs/community/llama_packs/index.md
+++ b/docs/docs/community/llama_packs/index.md
@@ -8,7 +8,7 @@ This directly tackles a big pain point in building LLM apps; every use case requ
 
 They can be used in two ways:
 
-- On one hand, they are **prepackaged modules** that can be initialized with parameters and run out of the box to achieve a given use case (whether that’s a full RAG pipeline, application template, or more). You can also import submodules (e.g. LLMs, query engines) to use directly.
+- On one hand, they are **prepackaged modules** that can be initialized with parameters and run out of the box to achieve a given use case (whether that’s a full RAG flow, application template, or more). You can also import submodules (e.g. LLMs, query engines) to use directly.
 - On the other hand, LlamaPacks are **templates** that you can inspect, modify, and use.
 
 **All packs are found on [LlamaHub](https://llamahub.ai/).** Go to the dropdown menu and select "LlamaPacks" to filter by packs.

--- a/docs/docs/examples/workflow/rag.ipynb
+++ b/docs/docs/examples/workflow/rag.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RAG Workflow with Reranking\n",
+    "\n",
+    "This notebook walks through setting up a `Workflow` to perform basic RAG with reranking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U llama-index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Designing the Workflow"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/docs/examples/workflow/rag.ipynb
+++ b/docs/docs/examples/workflow/rag.ipynb
@@ -19,16 +19,268 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir -p data\n",
+    "!wget --user-agent \"Mozilla\" \"https://arxiv.org/pdf/2307.09288.pdf\" -O \"data/llama2.pdf\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Designing the Workflow"
+    "Since workflows are async first, this all runs fine in a notebook. If you were running in your own code, you would want to use `asyncio.run()` to start an async event loop if one isn't already running.\n",
+    "\n",
+    "```python\n",
+    "async def main():\n",
+    "    <async code>\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    import asyncio\n",
+    "    asyncio.run(main())\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Designing the Workflow\n",
+    "\n",
+    "RAG + Reranking consists of some clearly defined steps\n",
+    "1. Indexing data, creating an index\n",
+    "2. Using that index + a query to retrieve relevant text chunks\n",
+    "3. Rerank the text retrieved text chunks using the original query\n",
+    "4. Synthesizing a final response\n",
+    "\n",
+    "With this in mind, we can create events and workflow steps to follow this process!\n",
+    "\n",
+    "### The Workflow Events\n",
+    "\n",
+    "To handle these steps, we need to define a few events:\n",
+    "1. An event to pass retrieved nodes to the reranker\n",
+    "2. An event to pass reranked nodes to the synthesizer\n",
+    "\n",
+    "The other steps will use the built-in `StartEvent` and `StopEvent` events."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.workflow import Event\n",
+    "from llama_index.core.schema import NodeWithScore\n",
+    "\n",
+    "\n",
+    "class RetrieverEvent(Event):\n",
+    "    \"\"\"Result of running retrieval\"\"\"\n",
+    "\n",
+    "    nodes: list[NodeWithScore]\n",
+    "\n",
+    "\n",
+    "class RerankEvent(Event):\n",
+    "    \"\"\"Result of running reranking on retrieved nodes\"\"\"\n",
+    "\n",
+    "    nodes: list[NodeWithScore]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The Workflow Itself\n",
+    "\n",
+    "With our events defined, we can construct our workflow and steps. \n",
+    "\n",
+    "Note that the workflow automatically validates itself using type annotations, so the type annotations on our steps are very helpful!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import SimpleDirectoryReader, VectorStoreIndex\n",
+    "from llama_index.core.response_synthesizers import CompactAndRefine\n",
+    "from llama_index.core.postprocessor.llm_rerank import LLMRerank\n",
+    "from llama_index.core.workflow import (\n",
+    "    Context,\n",
+    "    Workflow,\n",
+    "    StartEvent,\n",
+    "    StopEvent,\n",
+    "    step,\n",
+    ")\n",
+    "\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "\n",
+    "\n",
+    "class RAGWorkflow(Workflow):\n",
+    "    @step(pass_context=True)\n",
+    "    async def ingest(self, ctx: Context, ev: StartEvent) -> StopEvent | None:\n",
+    "        \"\"\"Entry point to ingest a document, triggered by a StartEvent with `dirname`.\"\"\"\n",
+    "        dirname = ev.get(\"dirname\")\n",
+    "        if not dirname:\n",
+    "            return None\n",
+    "\n",
+    "        documents = SimpleDirectoryReader(dirname).load_data()\n",
+    "        ctx.data[\"index\"] = VectorStoreIndex.from_documents(\n",
+    "            documents=documents,\n",
+    "            embed_model=OpenAIEmbedding(model_name=\"text-embedding-3-small\"),\n",
+    "        )\n",
+    "        return StopEvent(result=f\"Indexed {len(documents)} documents.\")\n",
+    "\n",
+    "    @step(pass_context=True)\n",
+    "    async def retrieve(\n",
+    "        self, ctx: Context, ev: StartEvent\n",
+    "    ) -> RetrieverEvent | None:\n",
+    "        \"Entry point for RAG, triggered by a StartEvent with `query`.\"\n",
+    "        query = ev.get(\"query\")\n",
+    "        if not query:\n",
+    "            return None\n",
+    "\n",
+    "        print(f\"Query the database with: {query}\")\n",
+    "\n",
+    "        # store the query in the global context\n",
+    "        ctx.data[\"query\"] = query\n",
+    "\n",
+    "        # get the index from the global context\n",
+    "        index = ctx.data.get(\"index\")\n",
+    "        if index is None:\n",
+    "            print(\"Index is empty, load some documents before querying!\")\n",
+    "            return None\n",
+    "\n",
+    "        retriever = index.as_retriever(similarity_top_k=2)\n",
+    "        nodes = retriever.retrieve(query)\n",
+    "        print(f\"Retrieved {len(nodes)} nodes.\")\n",
+    "        return RetrieverEvent(nodes=nodes)\n",
+    "\n",
+    "    @step(pass_context=True)\n",
+    "    async def rerank(self, ctx: Context, ev: RetrieverEvent) -> RerankEvent:\n",
+    "        # Rerank the nodes\n",
+    "        ranker = LLMRerank(\n",
+    "            choice_batch_size=5, top_n=3, llm=OpenAI(model=\"gpt-4o-mini\")\n",
+    "        )\n",
+    "        print(ctx.data.get(\"query\"), flush=True)\n",
+    "        new_nodes = ranker.postprocess_nodes(\n",
+    "            ev.nodes, query_str=ctx.data.get(\"query\")\n",
+    "        )\n",
+    "        print(f\"Reranked nodes to {len(new_nodes)}\")\n",
+    "        return RerankEvent(nodes=new_nodes)\n",
+    "\n",
+    "    @step(pass_context=True)\n",
+    "    async def synthesize(self, ctx: Context, ev: RerankEvent) -> StopEvent:\n",
+    "        \"\"\"Return a streaming response using reranked nodes.\"\"\"\n",
+    "        llm = OpenAI(model=\"gpt-4o-mini\")\n",
+    "        summarizer = CompactAndRefine(llm=llm, streaming=True, verbose=True)\n",
+    "        query = ctx.data.get(\"query\")\n",
+    "\n",
+    "        response = await summarizer.asynthesize(query, nodes=ev.nodes)\n",
+    "        return StopEvent(result=response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And thats it! Let's explore the workflow we wrote a bit.\n",
+    "\n",
+    "- We have two entry points (the steps that accept `StartEvent`)\n",
+    "- The steps themselves decide when they can run\n",
+    "- The workflow context is used to store the user query\n",
+    "- The nodes are passed around, and finally a streaming response is returned"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run the Workflow!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Indexed 77 documents.'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w = RAGWorkflow()\n",
+    "\n",
+    "# Ingest the documents\n",
+    "await w.run(dirname=\"data\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Query the database with: How was Llama2 trained?\n",
+      "Retrieved 2 nodes.\n",
+      "Llama 2 was trained through a multi-step process that began with pretraining using publicly available online sources. This was followed by the creation of an initial version of Llama 2-Chat through supervised fine-tuning. The model was then iteratively refined using Reinforcement Learning with Human Feedback (RLHF) methodologies, which included techniques like rejection sampling and Proximal Policy Optimization (PPO). \n",
+      "\n",
+      "During pretraining, the model utilized an optimized auto-regressive transformer architecture, incorporating robust data cleaning, updated data mixes, and training on a significantly larger dataset of 2 trillion tokens. The training process also involved increased context length and the use of grouped-query attention (GQA) to enhance inference scalability. \n",
+      "\n",
+      "The training employed the AdamW optimizer with specific hyperparameters, a cosine learning rate schedule, and gradient clipping. The models were pretrained on Meta’s Research SuperCluster and internal production clusters, utilizing NVIDIA A100 GPUs for the training process."
+     ]
+    }
+   ],
+   "source": [
+    "# Run a query\n",
+    "result = await w.run(query=\"How was Llama2 trained?\")\n",
+    "async for chunk in result.async_response_gen():\n",
+    "    print(chunk, end=\"\", flush=True)"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "llama-index-cDlKpkFt-py3.11",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/docs/examples/workflow/reflection.ipynb
+++ b/docs/docs/examples/workflow/reflection.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Workflow for Reliable Structured Outputs\n",
+    "\n",
+    "This notebook walks through setting up a `Workflow` to provide reliable structured outputs through retries and reflection on mistakes.\n",
+    "\n",
+    "This notebook works best with an open-source LLM, so we will use `Ollama`. If you don't already have Ollama running, visit [https://ollama.com](https://ollama.com) to get started and download the model you want to use. (In this case, we did `ollama pull llama3.1` before running this notebook)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U llama-index llama-index-llms-ollama"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Designing the Workflow"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/docs/examples/workflow/reflection.ipynb
+++ b/docs/docs/examples/workflow/reflection.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Workflow for Reliable Structured Outputs\n",
+    "# Reflection Workflow for Structured Outputs\n",
     "\n",
     "This notebook walks through setting up a `Workflow` to provide reliable structured outputs through retries and reflection on mistakes.\n",
     "\n",
@@ -24,13 +24,264 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Designing the Workflow"
+    "Since workflows are async first, this all runs fine in a notebook. If you were running in your own code, you would want to use `asyncio.run()` to start an async event loop if one isn't already running.\n",
+    "\n",
+    "```python\n",
+    "async def main():\n",
+    "    <async code>\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    import asyncio\n",
+    "    asyncio.run(main())\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Designing the Workflow\n",
+    "\n",
+    "To validate the structured output of an LLM, we need only two steps:\n",
+    "1. Generate the structured output\n",
+    "2. Validate that the output is proper JSON\n",
+    "\n",
+    "The key thing here is that, if the output is invalid, we **loop** until it is, giving error feedback to the next generation.\n",
+    "\n",
+    "### The Workflow Events\n",
+    "\n",
+    "To handle these steps, we need to define a few events:\n",
+    "1. An event to pass on the generated extraction \n",
+    "2. An event to give feedback when the extraction is invalid\n",
+    "\n",
+    "The other steps will use the built-in `StartEvent` and `StopEvent` events."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.workflow import Event\n",
+    "\n",
+    "\n",
+    "class ExtractionDone(Event):\n",
+    "    output: str\n",
+    "    passage: str\n",
+    "\n",
+    "\n",
+    "class ValidationErrorEvent(Event):\n",
+    "    error: str\n",
+    "    wrong_output: str\n",
+    "    passage: str"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Item to Extract\n",
+    "\n",
+    "To prompt our model, lets define a pydantic model we want to extract."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel\n",
+    "\n",
+    "\n",
+    "class Car(BaseModel):\n",
+    "    brand: str\n",
+    "    model: str\n",
+    "    power: int\n",
+    "\n",
+    "\n",
+    "class CarCollection(BaseModel):\n",
+    "    cars: list[Car]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The Workflow Itself\n",
+    "\n",
+    "With our events defined, we can construct our workflow and steps. \n",
+    "\n",
+    "Note that the workflow automatically validates itself using type annotations, so the type annotations on our steps are very helpful!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "from llama_index.core.workflow import Workflow, StartEvent, StopEvent, step\n",
+    "from llama_index.llms.ollama import Ollama\n",
+    "\n",
+    "EXTRACTION_PROMPT = \"\"\"\n",
+    "Context information is below:\n",
+    "---------------------\n",
+    "{passage}\n",
+    "---------------------\n",
+    "\n",
+    "Given the context information and not prior knowledge, create a JSON object from the information in the context.\n",
+    "The JSON object must follow the JSON schema:\n",
+    "{schema}\n",
+    "\n",
+    "\"\"\"\n",
+    "\n",
+    "REFLECTION_PROMPT = \"\"\"\n",
+    "You already created this output previously:\n",
+    "---------------------\n",
+    "{wrong_answer}\n",
+    "---------------------\n",
+    "\n",
+    "This caused the JSON decode error: {error}\n",
+    "\n",
+    "Try again, the response must contain only valid JSON code. Do not add any sentence before or after the JSON object.\n",
+    "Do not repeat the schema.\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "class ReflectionWorkflow(Workflow):\n",
+    "    @step()\n",
+    "    async def extract(\n",
+    "        self, ev: StartEvent | ValidationErrorEvent\n",
+    "    ) -> StopEvent | ExtractionDone:\n",
+    "        if isinstance(ev, StartEvent):\n",
+    "            passage = ev.get(\"passage\")\n",
+    "            if not passage:\n",
+    "                return StopEvent(result=\"Please provide some text in input\")\n",
+    "            reflection_prompt = \"\"\n",
+    "        elif isinstance(ev, ValidationErrorEvent):\n",
+    "            passage = ev.passage\n",
+    "            reflection_prompt = REFLECTION_PROMPT.format(\n",
+    "                wrong_answer=ev.wrong_output, error=ev.error\n",
+    "            )\n",
+    "\n",
+    "        llm = Ollama(model=\"llama3\", request_timeout=30)\n",
+    "        prompt = EXTRACTION_PROMPT.format(\n",
+    "            passage=passage, schema=CarCollection.schema_json()\n",
+    "        )\n",
+    "        if reflection_prompt:\n",
+    "            prompt += reflection_prompt\n",
+    "\n",
+    "        output = await llm.acomplete(prompt)\n",
+    "\n",
+    "        return ExtractionDone(output=str(output), passage=passage)\n",
+    "\n",
+    "    @step()\n",
+    "    async def validate(\n",
+    "        self, ev: ExtractionDone\n",
+    "    ) -> StopEvent | ValidationErrorEvent:\n",
+    "        try:\n",
+    "            json.loads(ev.output)\n",
+    "        except Exception as e:\n",
+    "            print(\"Validation failed, retrying...\")\n",
+    "            return ValidationErrorEvent(\n",
+    "                error=str(e), wrong_output=ev.output, passage=ev.passage\n",
+    "            )\n",
+    "\n",
+    "        return StopEvent(result=ev.output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And thats it! Let's explore the workflow we wrote a bit.\n",
+    "\n",
+    "- We have one entry point, `extract` (the steps that accept `StartEvent`)\n",
+    "- When `extract` finishes, it emits a `ExtractionDone` event\n",
+    "- `validate` runs and confirms the extraction:\n",
+    "  - If its ok, it emits `StopEvent` and halts the workflow\n",
+    "  - If nots not, it returns a `ValidationErrorEvent` with information about the error\n",
+    "- Any `ValidationErrorEvent` emitted will trigger the loop, and `extract` runs again!\n",
+    "- This continues until the structured output is validated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the Workflow!\n",
+    "\n",
+    "**NOTE:** With loops, we need to be mindful of runtime. Here, we set a timeout of 120s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running step extract\n",
+      "Step extract produced event ExtractionDone\n",
+      "Running step validate\n",
+      "Validation failed, retrying...\n",
+      "Step validate produced event ValidationErrorEvent\n",
+      "Running step extract\n",
+      "Step extract produced event ExtractionDone\n",
+      "Running step validate\n",
+      "Step validate produced event StopEvent\n"
+     ]
+    }
+   ],
+   "source": [
+    "w = ReflectionWorkflow(timeout=120, verbose=True)\n",
+    "\n",
+    "# Run the workflow\n",
+    "ret = await w.run(\n",
+    "    passage=\"I own two cars: a Fiat Panda with 45Hp and a Honda Civic with 330Hp.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{ \"cars\": [ { \"brand\": \"Fiat\", \"model\": \"Panda\", \"power\": 45 }, { \"brand\": \"Honda\", \"model\": \"Civic\", \"power\": 330 } ] }\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(ret)"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "llama-index-cDlKpkFt-py3.11",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/docs/getting_started/concepts.md
+++ b/docs/docs/getting_started/concepts.md
@@ -10,10 +10,10 @@ There are endless use cases for data-backed LLM applications but they can be rou
 Pydantic extractors allow you to specify a precise data structure to extract from your data and use LLMs to fill in the missing pieces in a type-safe way. This is useful for extracting structured data from unstructured sources like PDFs, websites, and more, and is key to automating workflows.
 
 [**Query Engines**](../module_guides/deploying/query_engine/index.md):
-A query engine is an end-to-end pipeline that allows you to ask questions over your data. It takes in a natural language query, and returns a response, along with reference context retrieved and passed to the LLM.
+A query engine is an end-to-end flow that allows you to ask questions over your data. It takes in a natural language query, and returns a response, along with reference context retrieved and passed to the LLM.
 
 [**Chat Engines**](../module_guides/deploying/chat_engines/index.md):
-A chat engine is an end-to-end pipeline for having a conversation with your data (multiple back-and-forth instead of a single question-and-answer).
+A chat engine is an end-to-end flow for having a conversation with your data (multiple back-and-forth instead of a single question-and-answer).
 
 [**Agents**](../module_guides/deploying/agents/index.md):
 An agent is an automated decision-maker powered by an LLM that interacts with the world via a set of [tools](../module_guides/deploying/agents/tools.md). Agents can take an arbitrary number of steps to complete a given task, dynamically deciding on the best course of action rather than following pre-determined steps. This gives it additional flexibility to tackle more complex tasks.
@@ -35,7 +35,7 @@ Even if what you're building is a chatbot or an agent, you'll want to know RAG t
 
 There are five key stages within RAG, which in turn will be a part of most larger applications you build. These are:
 
-- **Loading**: this refers to getting your data from where it lives -- whether it's text files, PDFs, another website, a database, or an API -- into your pipeline. [LlamaHub](https://llamahub.ai/) provides hundreds of connectors to choose from.
+- **Loading**: this refers to getting your data from where it lives -- whether it's text files, PDFs, another website, a database, or an API -- into your workflow. [LlamaHub](https://llamahub.ai/) provides hundreds of connectors to choose from.
 
 - **Indexing**: this means creating a data structure that allows for querying the data. For LLMs this nearly always means creating `vector embeddings`, numerical representations of the meaning of your data, as well as numerous other metadata strategies to make it easy to accurately find contextually relevant data.
 
@@ -43,7 +43,7 @@ There are five key stages within RAG, which in turn will be a part of most large
 
 - **Querying**: for any given indexing strategy there are many ways you can utilize LLMs and LlamaIndex data structures to query, including sub-queries, multi-step queries and hybrid strategies.
 
-- **Evaluation**: a critical step in any pipeline is checking how effective it is relative to other strategies, or when you make changes. Evaluation provides objective measures of how accurate, faithful and fast your responses to queries are.
+- **Evaluation**: a critical step in any flow is checking how effective it is relative to other strategies, or when you make changes. Evaluation provides objective measures of how accurate, faithful and fast your responses to queries are.
 
 ![](../_static/getting_started/stages.png)
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -49,7 +49,7 @@ LlamaIndex imposes no restriction on how you use LLMs. You can use LLMs as auto-
 - **Data connectors** ingest your existing data from their native source and format. These could be APIs, PDFs, SQL, and (much) more.
 - **Data indexes** structure your data in intermediate representations that are easy and performant for LLMs to consume.
 - **Engines** provide natural language access to your data. For example:
-    - Query engines are powerful interfaces for question-answering (e.g. a RAG pipeline).
+    - Query engines are powerful interfaces for question-answering (e.g. a RAG flow).
     - Chat engines are conversational interfaces for multi-message, "back and forth" interactions with your data.
 - **Agents** are LLM-powered knowledge workers augmented by tools, from simple helper functions to API integrations and more.
 - **Observability/Evaluation** integrations that enable you to rigorously experiment, evaluate, and monitor your app in a virtuous cycle.

--- a/docs/docs/module_guides/evaluating/evaluating_with_llamadatasets.md
+++ b/docs/docs/module_guides/evaluating/evaluating_with_llamadatasets.md
@@ -105,7 +105,7 @@ contexts retrieved by the RAG system to generated the predicted response.
 ## Where To Find `LabelledRagDataset`'s
 
 You can find all of the `LabelledRagDataset`'s in [llamahub](https://llamahub.ai). You can browse each one of these and decide
-if you do decide that you'd like to use it to benchmark your RAG pipeline, then
+if you do decide that you'd like to use it to benchmark your RAG workflow, then
 you can download the dataset as well as the source `Document`'s conveniently thru
 one of two ways: the `llamaindex-cli` or through Python code using the
 `download_llama_dataset` utility function.

--- a/docs/docs/module_guides/evaluating/index.md
+++ b/docs/docs/module_guides/evaluating/index.md
@@ -32,7 +32,7 @@ These evaluation modules are in the following forms:
 
 #### Question Generation
 
-In addition to evaluating queries, LlamaIndex can also use your data to generate questions to evaluate on. This means that you can automatically generate questions, and then run an evaluation pipeline to test if the LLM can actually answer questions accurately using your data.
+In addition to evaluating queries, LlamaIndex can also use your data to generate questions to evaluate on. This means that you can automatically generate questions, and then run an evaluation flow to test if the LLM can actually answer questions accurately using your data.
 
 ### Retrieval Evaluation
 

--- a/docs/docs/module_guides/evaluating/usage_pattern.md
+++ b/docs/docs/module_guides/evaluating/usage_pattern.md
@@ -166,7 +166,7 @@ for source_node in response.source_nodes:
 
 ## Question Generation
 
-LlamaIndex can also generate questions to answer using your data. Using in combination with the above evaluators, you can create a fully automated evaluation pipeline over your data.
+LlamaIndex can also generate questions to answer using your data. Using in combination with the above evaluators, you can create a fully automated evaluation flow over your data.
 
 ```python
 from llama_index.core import SimpleDirectoryReader

--- a/docs/docs/module_guides/observability/index.md
+++ b/docs/docs/module_guides/observability/index.md
@@ -281,7 +281,7 @@ tru_query_engine.query("What did the author do growing up?")
 
 ### HoneyHive
 
-HoneyHive allows users to trace the execution flow of any LLM pipeline. Users can then debug and analyze their traces, or customize feedback on specific trace events to create evaluation or fine-tuning datasets from production.
+HoneyHive allows users to trace the execution flow of any LLM workflow. Users can then debug and analyze their traces, or customize feedback on specific trace events to create evaluation or fine-tuning datasets from production.
 
 #### Usage Pattern
 
@@ -291,7 +291,7 @@ from llama_index.core import set_global_handler
 set_global_handler(
     "honeyhive",
     project="My HoneyHive Project",
-    name="My LLM Pipeline Name",
+    name="My LLM Workflow Name",
     api_key="MY HONEYHIVE API KEY",
 )
 
@@ -303,7 +303,7 @@ from llama_index.core import Settings
 
 # hh_tracer = HoneyHiveLlamaIndexTracer(
 #     project="My HoneyHive Project",
-#     name="My LLM Pipeline Name",
+#     name="My LLM Workflow Name",
 #     api_key="MY HONEYHIVE API KEY",
 # )
 # Settings.callback_manager = CallbackManager([hh_tracer])

--- a/docs/docs/module_guides/querying/index.md
+++ b/docs/docs/module_guides/querying/index.md
@@ -4,9 +4,9 @@ Querying is the most important part of your LLM application. To learn more about
 
 If you wish to combine advanced reasoning with tool use, check out our [agents](../deploying/agents/index.md) guide.
 
-## Query Pipeline
+## Query Workflows
 
-You can create query pipelines/chains with ease with our declarative `QueryPipeline` interface. Check out our [query pipeline guide](pipeline/index.md) for more details.
+You can create workflows for querying with ease, using our event-driven `Workflow` interface. Check out our [workflow guide](workflow/index.md) for more details.
 
 Otherwise check out how to use our query modules as standalone components 👇.
 

--- a/docs/docs/module_guides/querying/node_postprocessors/index.md
+++ b/docs/docs/module_guides/querying/node_postprocessors/index.md
@@ -9,7 +9,7 @@ In LlamaIndex, node postprocessors are most commonly applied within a query engi
 LlamaIndex offers several node postprocessors for immediate use, while also providing a simple API for adding your own custom postprocessors.
 
 !!! tip
-    Confused about where node postprocessor fits in the pipeline? Read about [high-level concepts](../../../getting_started/concepts.md)
+    Confused about where node postprocessor fits in the RAG workflow? Read about [high-level concepts](../../../getting_started/concepts.md)
 
 ## Usage Pattern
 

--- a/docs/docs/module_guides/querying/pipeline/index.md
+++ b/docs/docs/module_guides/querying/pipeline/index.md
@@ -1,5 +1,8 @@
 # Query Pipeline
 
+!!! warning
+    Query Pipelines have recently gone into a feature-freeze/deprecation phase. If you want to orchestrate modules, we suggest checking out [workflows](../../workflow/index.md).
+
 ## Concept
 
 LlamaIndex provides a declarative query API that allows you to chain together different modules in order to orchestrate simple-to-advanced workflows over your data.

--- a/docs/docs/module_guides/querying/response_synthesizers/index.md
+++ b/docs/docs/module_guides/querying/response_synthesizers/index.md
@@ -9,7 +9,7 @@ The method for doing this can take many forms, from as simple as iterating over 
 When used in a query engine, the response synthesizer is used after nodes are retrieved from a retriever, and after any node-postprocessors are ran.
 
 !!! tip
-    Confused about where response synthesizer fits in the pipeline? Read the [high-level concepts](../../../getting_started/concepts.md)
+    Confused about where response synthesizer fits in the RAG workflow? Read the [high-level concepts](../../../getting_started/concepts.md)
 
 ## Usage Pattern
 

--- a/docs/docs/module_guides/querying/retriever/index.md
+++ b/docs/docs/module_guides/querying/retriever/index.md
@@ -8,7 +8,7 @@ It can be built on top of [indexes](../../indexing/index.md), but can also be de
 It is used as a key building block in [query engines](../../deploying/query_engine/index.md) (and [Chat Engines](../../deploying/chat_engines/index.md)) for retrieving relevant context.
 
 !!! tip
-    Confused about where retriever fits in the pipeline? Read about [high-level concepts](../../../getting_started/concepts.md)
+    Confused about where retriever fits in the RAG workflow? Read about [high-level concepts](../../../getting_started/concepts.md)
 
 ## Usage Pattern
 

--- a/docs/docs/module_guides/querying/retriever/retrievers.md
+++ b/docs/docs/module_guides/querying/retriever/retrievers.md
@@ -16,7 +16,7 @@ Check out our comprehensive guides on various retriever modules, many of which c
 ### Advanced Retrieval and Search
 
 These guides contain advanced retrieval techniques. Some are common like keyword/hybrid search, reranking, and more.
-Some are specific to LLM + RAG pipelines, like small-to-big and auto-merging retrieval.
+Some are specific to LLM + RAG workflows, like small-to-big and auto-merging retrieval.
 
 - [Define Custom Retriever](../../../examples/query_engine/CustomRetrievers.ipynb)
 - [BM25 Hybrid Retriever](../../../examples/retrievers/bm25_retriever.ipynb)

--- a/docs/docs/module_guides/querying/structured_outputs/query_engine.md
+++ b/docs/docs/module_guides/querying/structured_outputs/query_engine.md
@@ -1,7 +1,7 @@
 # (Deprecated) Query Engines + Pydantic Outputs
 
 !!! tip
-    This guide references a deprecated method of extracting structured outputs in a RAG pipeline. Check out our [structured output starter guide](../../../examples/structured_outputs/structured_outputs.ipynb) for more details.
+    This guide references a deprecated method of extracting structured outputs in a RAG workflow. Check out our [structured output starter guide](../../../examples/structured_outputs/structured_outputs.ipynb) for more details.
 
 Using `index.as_query_engine()` and it's underlying `RetrieverQueryEngine`, we can support structured pydantic outputs without an additional LLM calls (in contrast to a typical output parser.)
 

--- a/docs/docs/module_guides/supporting_modules/settings.md
+++ b/docs/docs/module_guides/supporting_modules/settings.md
@@ -1,6 +1,6 @@
 # Configuring Settings
 
-The `Settings` is a bundle of commonly used resources used during the indexing and querying stage in a LlamaIndex pipeline/application.
+The `Settings` is a bundle of commonly used resources used during the indexing and querying stage in a LlamaIndex workflow/application.
 
 You can use it to set the [global configuration](#setting-global-configuration). Local configurations (transformations, LLMs, embedding models) can be passed directly into the interfaces that make use of them.
 

--- a/docs/docs/module_guides/workflow/index.md
+++ b/docs/docs/module_guides/workflow/index.md
@@ -1,0 +1,203 @@
+# Workflows
+
+A `Workflow` in LlamaIndex is an event-driven abstraction used to chain together several events. Workflows are made up of `steps`, with each step responsible for handling certain event types and emitting new events.
+
+`Workflow`s in LlamaIndex work by decorating function with a `@step()` decorator. This is used to infer the input and output types of each workflow for validation, and ensures each step only runs when an accepted event is ready.
+
+You can create a `Workflow` to do anything! Build an agent, a RAG flow, an extraction flow, or anything else you want.
+
+Workflows are also automatically instrumented, so you get observability into each step using tools like [Arize Pheonix](../observability/index.md#arize-phoenix-local). (**NOTE:** Observability works for integrations that take advantage of the newer instrumentation system. Usage may vary.)
+
+## Getting Started
+
+As an illustrative example, let's consider a naive workflow where a joke is generated and then critiqued.
+
+```python
+from llama_index.core.workflow import (
+    Event,
+    StartEvent,
+    StopEvent,
+    Workflow,
+    step,
+)
+
+# `pip install llama-index-llms-openai` if you don't already have it
+from llama_index.llms.openai import OpenAI
+
+
+class JokeEvent(Event):
+    joke: str
+
+
+class JokeFlow(Workflow):
+    llm = OpenAI()
+
+    @step()
+    async def generate_joke(self, ev: StartEvent) -> JokeEvent:
+        topic = ev.get("topic")
+
+        prompt = f"Write your best joke about {topic}."
+        response = await self.llm.acomplete(prompt)
+        return JokeEvent(joke=str(response))
+
+    @step()
+    async def critique_joke(self, ev: JokeEvent) -> StopEvent:
+        joke = ev.joke
+
+        prompt = f"Give a thorough analysis and critique of the following joke: {joke}"
+        response = await self.llm.acomplete(prompt)
+        return StopEvent(result=str(response))
+
+
+w = JokeFlow(timeout=60, verbose=False)
+result = await w.run(topic="pirates")
+print(str(result))
+```
+
+There's a few moving pieces here, so let's go through this piece by piece.
+
+### Defining Workflow Events
+
+```python
+class JokeEvent(Event):
+    joke: str
+```
+
+Events are user-defined pydantic objects. You control the attributes and any other auxiliary methods. In this case, our workflow relies on a single user-defined event, the `JokeEvent`.
+
+### Setting up the Workflow Class
+
+```python
+class JokeFlow(Workflow):
+    llm = OpenAI(model="gpt-4o-mini")
+    ...
+```
+
+Our workflow is implemented by subclassing the `Workflow` class. For simplicity, we attached a static `OpenAI` llm instance.
+
+### Workflow Entry Points
+
+```python
+class JokeFlow(Workflow):
+    ...
+
+    @step()
+    async def generate_joke(self, ev: StartEvent) -> JokeEvent:
+        topic = ev.get("topic")
+
+        prompt = f"Write your best joke about {topic}."
+        response = await self.llm.acomplete(prompt)
+        return JokeEvent(joke=str(response))
+
+    ...
+```
+
+Here, we come to the entry-point of our workflow. While events are use-defined, there are two special-case events, the `StartEvent` and the `StopEvent`. Here, the `StartEvent` signifies where to send the initial workflow input. Since the input can be anything, its accessed safely using the `.get()` method.
+
+At this point, you may have noticed that we haven't explicitly told the workflow what events are handled by which steps. Instead, the `@step()` decorator is used to infer the input and output types of each step. Furthermore, these inferred input and output types are also used to verify for you that the workflow is valid before running!
+
+### Workflow Exit Points
+
+```python
+class JokeFlow(Workflow):
+    ...
+
+    @step()
+    async def critique_joke(self, ev: JokeEvent) -> StopEvent:
+        joke = ev.joke
+
+        prompt = f"Give a thorough analysis and critique of the following joke: {joke}"
+        response = await self.llm.acomplete(prompt)
+        return StopEvent(result=str(response))
+
+    ...
+```
+
+Here, we have our second, and last step, in the workflow. We know its the last step because the special `StopEvent` is returned. When the workflow encounters a returned `StopEvent`, it immediately stops the workflow and returns whatever the result was.
+
+In this case, the result is a string, but it could be a dictionary, list, or any other object.
+
+### Running the Workflow
+
+```python
+w = JokeFlow(timeout=60, verbose=False)
+result = await w.run(topic="pirates")
+print(str(result))
+```
+
+Lastly, we create and run the workflow. There are some settings like timeouts (in seconds) and verbosity to help with debugging.
+
+The `.run()` method is async, so we use await here to wait for the result.
+
+## Working with Global Context/State
+
+Optionally, you can choose to use global context between steps. For example, maybe multiple steps access the original `query` input from the user. You can store this in global context so that every step has access.
+
+```python
+from llama_index.core.workflow import Context
+
+
+@step(pass_context=True)
+async def query(self, ctx, Context, ev: QueryEvent) -> StopEvent:
+    # retrieve from context
+    query = ctx.get("query")
+
+    # store in context
+    ctx["key"] = "val"
+
+    result = run_query(query)
+    return StopEvent(result=result)
+```
+
+## Decorating non-class Functions
+
+You can also decorate and attach steps to a workflow without subclassing it.
+
+Below is the `JokeFlow` from earlier, but defined without subclassing.
+
+```python
+from llama_index.core.workflow import (
+    Event,
+    StartEvent,
+    StopEvent,
+    Workflow,
+    step,
+)
+
+
+class JokeEvent(Event):
+    joke: str
+
+
+joke_flow = Workflow(timeout=60, verbose=True)
+
+
+@step(workflow=joke_flow)
+async def generate_joke(ev: StartEvent) -> JokeEvent:
+    topic = ev.get("topic")
+
+    prompt = f"Write your best joke about {topic}."
+    response = await llm.acomplete(prompt)
+    return JokeEvent(joke=str(response))
+
+
+@step(workflow=joke_flow)
+async def critique_joke(ev: JokeEvent) -> StopEvent:
+    joke = ev.joke
+
+    prompt = (
+        f"Give a thorough analysis and critique of the following joke: {joke}"
+    )
+    response = await llm.acomplete(prompt)
+    return StopEvent(result=str(response))
+```
+
+## Examples
+
+You can find many useful examples of using workflows in the notebooks below:
+
+- [RAG + Reranking](TODO)
+- [Reliable Structured Generation](TODO)
+- [Function Calling Agent](TODO)
+- [ReAct Agent](TODO)
+- [Context Chat Engine](TODO)

--- a/docs/docs/module_guides/workflow/index.md
+++ b/docs/docs/module_guides/workflow/index.md
@@ -196,8 +196,8 @@ async def critique_joke(ev: JokeEvent) -> StopEvent:
 
 You can find many useful examples of using workflows in the notebooks below:
 
-- [RAG + Reranking](TODO)
-- [Reliable Structured Generation](TODO)
+- [RAG + Reranking](../../examples/workflow/rag.ipynb)
+- [Reliable Structured Generation](../../examples/workflow/reflection.ipynb)
 - [Function Calling Agent](TODO)
 - [ReAct Agent](TODO)
 - [Context Chat Engine](TODO)

--- a/docs/docs/optimizing/advanced_retrieval/advanced_retrieval.md
+++ b/docs/docs/optimizing/advanced_retrieval/advanced_retrieval.md
@@ -22,7 +22,7 @@ More resources are below.
 
 ## Query Transformations
 
-A user query can be transformed before it enters a pipeline (query engine, agent, and more). See resources below on query transformations:
+A user query can be transformed before it enters a flow (query engine, agent, and more). See resources below on query transformations:
 
 - [Query Transform Cookbook](../../examples/query_transformations/query_transform_cookbook.ipynb)
 - [Query Transformations Docs](../../optimizing/advanced_retrieval/query_transformations.md)

--- a/docs/docs/optimizing/agentic_strategies/agentic_strategies.md
+++ b/docs/docs/optimizing/agentic_strategies/agentic_strategies.md
@@ -1,6 +1,6 @@
 # Agentic strategies
 
-You can build agents on top of your existing LlamaIndex RAG pipeline to empower it with automated decision capabilities.
+You can build agents on top of your existing LlamaIndex RAG workflow to empower it with automated decision capabilities.
 A lot of modules (routing, query transformations, and more) are already agentic in nature in that they use LLMs for decision making.
 
 ## Simpler Agentic Strategies

--- a/docs/docs/optimizing/basic_strategies/basic_strategies.md
+++ b/docs/docs/optimizing/basic_strategies/basic_strategies.md
@@ -1,6 +1,6 @@
 # Basic Strategies
 
-There are many easy things to try, when you need to quickly squeeze out extra performance and optimize your RAG pipeline.
+There are many easy things to try, when you need to quickly squeeze out extra performance and optimize your RAG workflow.
 
 ## Prompt Engineering
 
@@ -9,7 +9,7 @@ should be one of the first things you try.
 
 Some tasks are listed below, from simple to advanced.
 
-1. Try inspecting the prompts used in your RAG pipeline (e.g. the question–answering prompt) and customizing it.
+1. Try inspecting the prompts used in your RAG workflow (e.g. the question–answering prompt) and customizing it.
 
 - [Customizing Prompts](../../examples/prompts/prompt_mixin.ipynb)
 - [Advanced Prompts](../../examples/prompts/advanced_prompts.ipynb)

--- a/docs/docs/optimizing/building_rag_from_scratch.md
+++ b/docs/docs/optimizing/building_rag_from_scratch.md
@@ -8,7 +8,7 @@ Out of the box abstractions include:
 - High-level query and retriever code e.g. `VectorStoreIndex.as_retriever()` and `VectorStoreIndex.as_query_engine()`
 - High-level agent abstractions e.g. `OpenAIAgent`
 
-Instead of using these, the goal here is to educate users on what's going on under the hood. By showing you the underlying algorithms for constructing RAG and agent pipelines, you can then be empowered to create your own custom LLM workflows (while still using LlamaIndex abstractions at any level of granularity that makes sense).
+Instead of using these, the goal here is to educate users on what's going on under the hood. By showing you the underlying algorithms for constructing RAG and agent workflows, you can then be empowered to create your own custom LLM workflows (while still using LlamaIndex abstractions at any level of granularity that makes sense).
 
 We show how to build an app from scratch, component by component. For the sake of focus, each tutorial will show how to build a specific component from scratch while using out-of-the-box abstractions for other components. **NOTE**: This is a WIP document, we're in the process of fleshing this out!
 
@@ -53,7 +53,7 @@ Learn how to build common LLM-based eval modules (correctness, faithfulness) usi
 
 ## Building Advanced RAG from Scratch
 
-These tutorials will show you how to build advanced functionality beyond the basic RAG pipeline. Especially helpful for advanced users with custom workflows / production needs.
+These tutorials will show you how to build advanced functionality beyond the basic RAG workflow. Especially helpful for advanced users with custom workflows / production needs.
 
 ### Building Hybrid Search from Scratch
 
@@ -63,7 +63,7 @@ Hybrid search is an advanced retrieval feature supported by many vector database
 
 ### Building a Router from Scratch
 
-Beyond the standard RAG pipeline, this takes you one step towards automated decision making with LLMs by showing you how to build a router module from scratch.
+Beyond the standard RAG workflow, this takes you one step towards automated decision making with LLMs by showing you how to build a router module from scratch.
 
 - [Router from Scratch](../examples/low_level/router.ipynb)
 

--- a/docs/docs/optimizing/evaluation/component_wise_evaluation.md
+++ b/docs/docs/optimizing/evaluation/component_wise_evaluation.md
@@ -1,6 +1,6 @@
 # Component Wise Evaluation
 
-To do more in-depth evaluation of your pipeline, it helps to break it down into an evaluation of individual components.
+To do more in-depth evaluation of your workflow, it helps to break it down into an evaluation of individual components.
 
 For instance, a particular failure case may be due to a combination of not retrieving the right documents and also the LLM misunderstanding the context and hallucinating an incorrect result. Being able to isolate and deal with these issues separately can help reduce complexity and guide you in a step-by-step manner to a more satisfactory overall result.
 
@@ -20,7 +20,7 @@ Since most publically-available embedding and retrieval models are already bench
 
 For instance, after fine-tuning an embedding model on your dataset, it may be helpful to view whether and by how much its performance degrades on a diverse set of domains. This can be an indication of how much data drift may affect your retrieval accuracy, such as if you add documents to your RAG system outside of your fine-tuning training distribution.
 
-Here is a notebook showing how the BEIR dataset can be used with your retrieval pipeline.
+Here is a notebook showing how the BEIR dataset can be used with your retrieval flow.
 
 - [BEIR Evaluation](../../examples/evaluation/BeirEvaluation.ipynb)
 
@@ -28,7 +28,7 @@ We will be adding more methods to evaluate retrieval soon. This includes evaluat
 
 ## Evaluating the Query Engine Components (e.g. Without Retrieval)
 
-In this case, we may want to evaluate how specific components of a query engine (one which may generate sub-questions or follow-up questions) may perform on a standard benchmark. It can help give an indication of how far behind or ahead your retrieval pipeline is compared to alternate pipelines or models.
+In this case, we may want to evaluate how specific components of a query engine (one which may generate sub-questions or follow-up questions) may perform on a standard benchmark. It can help give an indication of how far behind or ahead your retrieval flow is compared to alternate flows or models.
 
 ### HotpotQA Dataset
 

--- a/docs/docs/optimizing/evaluation/e2e_evaluation.md
+++ b/docs/docs/optimizing/evaluation/e2e_evaluation.md
@@ -1,6 +1,6 @@
 # End-to-End Evaluation
 
-End-to-End evaluation should be the guiding signal for your RAG application - will my pipeline generate the right responses given the data sources and a set of queries?
+End-to-End evaluation should be the guiding signal for your RAG application - will my workflow generate the right responses given the data sources and a set of queries?
 
 While it helps initially to individually inspect queries and responses, as you deal with more failure and corner cases, it may stop being feasible to look at each query individually, and rather it may help instead to define a set of summary metrics or automated evaluation, and gain an intuition for what they might be telling you and where you might dive deeper.
 
@@ -34,7 +34,7 @@ Below is some example usage of the [evaluation modules](evaluation.md):
 
 ## Discovery - Sensitivity Testing
 
-With a complex pipeline, it may be unclear which parts of the pipeline are affecting your results.
+With a complex workflow, it may be unclear which parts of the flow are affecting your results.
 
 Sensitivity testing can be a good inroad into choosing which components to individually test or tweak more thoroughly, or which parts of your dataset (e.g. queries) may be producing problematic results.
 

--- a/docs/docs/optimizing/fine-tuning/fine-tuning.md
+++ b/docs/docs/optimizing/fine-tuning/fine-tuning.md
@@ -52,9 +52,9 @@ Finetuning gives you a 5-10% increase in retrieval evaluation metrics. You can t
 
 We have multiple guides showing how to use OpenAI's finetuning endpoints to fine-tune gpt-3.5-turbo to output GPT-4 responses for RAG/agents.
 
-We use GPT-4 to automatically generate questions from any unstructured context, and use a GPT-4 query engine pipeline to generate "ground-truth" answers. Our `OpenAIFineTuningHandler` callback automatically logs questions/answers to a dataset.
+We use GPT-4 to automatically generate questions from any unstructured context, and use a GPT-4 query engine flow to generate "ground-truth" answers. Our `OpenAIFineTuningHandler` callback automatically logs questions/answers to a dataset.
 
-We then launch a finetuning job, and get back a distilled model. We can evaluate this model with [Ragas](https://github.com/explodinggradients/ragas) to benchmark against a naive GPT-3.5 pipeline.
+We then launch a finetuning job, and get back a distilled model. We can evaluate this model with [Ragas](https://github.com/explodinggradients/ragas) to benchmark against a naive GPT-3.5 workflow.
 
 - [GPT-3.5 Fine-tuning Notebook (Colab)](https://colab.research.google.com/drive/1NgyCJVyrC2xcZ5lxt2frTU862v6eJHlc?usp=sharing)
 - [GPT-3.5 Fine-tuning Notebook (Notebook link)](../../examples/finetuning/openai_fine_tuning.ipynb)

--- a/docs/docs/optimizing/production_rag.md
+++ b/docs/docs/optimizing/production_rag.md
@@ -2,7 +2,7 @@
 
 Prototyping a RAG application is easy, but making it performant, robust, and scalable to a large knowledge corpus is hard.
 
-This guide contains a variety of tips and tricks to improve the performance of your RAG pipeline. We first outline
+This guide contains a variety of tips and tricks to improve the performance of your RAG workflow. We first outline
 some general techniques - they are loosely ordered in terms of most straightforward to most challenging.
 We then dive a bit more deeply into each technique, the use cases that it solves,
 and how to implement it with LlamaIndex!

--- a/docs/docs/understanding/querying/querying.md
+++ b/docs/docs/understanding/querying/querying.md
@@ -145,8 +145,8 @@ You may want to ensure your output is structured. See our [Query Engines + Pydan
 
 Also make sure to check out our entire [Structured Outputs](../../module_guides/querying/structured_outputs/index.md) guide.
 
-## Creating your own Query Pipeline
+## Creating your own Query Workflow
 
-If you want to design complex query flows, you can compose your own query pipeline across many different modules, from prompts/LLMs/output parsers to retrievers to response synthesizers to your own custom components.
+If you want to design complex query flows, you can compose your own query workflow across many different modules, from prompts/LLMs/output parsers to retrievers to response synthesizers to your own custom components.
 
-Take a look at our [Query Pipelines Module Guide](../../module_guides/querying/pipeline/index.md) for more details.
+Take a look at our [Workflow Guide](../../module_guides/querying/workflow/index.md) for more details.

--- a/docs/docs/understanding/using_llms/using_llms.md
+++ b/docs/docs/understanding/using_llms/using_llms.md
@@ -5,14 +5,14 @@
 
 One of the first steps when building an LLM-based application is which LLM to use; you can also use more than one if you wish.
 
-LLMs are used at multiple different stages of your pipeline:
+LLMs are used at multiple different stages of your workflow:
 
 - During **Indexing** you may use an LLM to determine the relevance of data (whether to index it at all) or you may use an LLM to summarize the raw data and index the summaries instead.
 - During **Querying** LLMs can be used in two ways:
   - During **Retrieval** (fetching data from your index) LLMs can be given an array of options (such as multiple different indices) and make decisions about where best to find the information you're looking for. An agentic LLM can also use _tools_ at this stage to query different data sources.
   - During **Response Synthesis** (turning the retrieved data into an answer) an LLM can combine answers to multiple sub-queries into a single coherent answer, or it can transform data, such as from unstructured text to JSON or another programmatic output format.
 
-LlamaIndex provides a single interface to a large number of different LLMs, allowing you to pass in any LLM you choose to any stage of the pipeline. It can be as simple as this:
+LlamaIndex provides a single interface to a large number of different LLMs, allowing you to pass in any LLM you choose to any stage of the flow. It can be as simple as this:
 
 ```python
 from llama_index.llms.openai import OpenAI
@@ -21,7 +21,7 @@ response = OpenAI().complete("Paul Graham is ")
 print(response)
 ```
 
-Usually, you will instantiate an LLM and pass it to `Settings`, which you then pass to other stages of the pipeline, as in this example:
+Usually, you will instantiate an LLM and pass it to `Settings`, which you then pass to other stages of the flow, as in this example:
 
 ```python
 from llama_index.llms.openai import OpenAI

--- a/docs/docs/use_cases/extraction.md
+++ b/docs/docs/use_cases/extraction.md
@@ -17,7 +17,7 @@ The simplest way to perform structured extraction is with our LLM classes. Take 
 There are also relevant sections for our LLM guides: [OpenAI](../examples/llm/openai.ipynb), [Anthropic](../examples/llm/anthropic.ipynb), and [Mistral](../examples/llm/mistralai.ipynb).
 
 #### In-depth Guides
-For a more comprehensive overview of structured data extraction with LlamaIndex, including lower-level modules, check out the following guides. Check out our standalone lower-level modules like Pydantic programs or as part of a RAG pipeline.
+For a more comprehensive overview of structured data extraction with LlamaIndex, including lower-level modules, check out the following guides. Check out our standalone lower-level modules like Pydantic programs or as part of a RAG workflow.
 We also have standalone output parsing modules that you can use yourself with an LLM / prompt.
 
 - [Structured Outputs](../module_guides/querying/structured_outputs/index.md)

--- a/docs/docs/use_cases/fine_tuning.md
+++ b/docs/docs/use_cases/fine_tuning.md
@@ -52,9 +52,9 @@ Finetuning gives you a 5-10% increase in retrieval evaluation metrics. You can t
 
 We have multiple guides showing how to use OpenAI's finetuning endpoints to fine-tune gpt-3.5-turbo to output GPT-4 responses for RAG/agents.
 
-We use GPT-4 to automatically generate questions from any unstructured context, and use a GPT-4 query engine pipeline to generate "ground-truth" answers. Our `OpenAIFineTuningHandler` callback automatically logs questions/answers to a dataset.
+We use GPT-4 to automatically generate questions from any unstructured context, and use a GPT-4 query engine flow to generate "ground-truth" answers. Our `OpenAIFineTuningHandler` callback automatically logs questions/answers to a dataset.
 
-We then launch a finetuning job, and get back a distilled model. We can evaluate this model with [Ragas](https://github.com/explodinggradients/ragas) to benchmark against a naive GPT-3.5 pipeline.
+We then launch a finetuning job, and get back a distilled model. We can evaluate this model with [Ragas](https://github.com/explodinggradients/ragas) to benchmark against a naive GPT-3.5 flow.
 
 - [GPT-3.5 Fine-tuning Notebook (Colab)](https://colab.research.google.com/drive/1NgyCJVyrC2xcZ5lxt2frTU862v6eJHlc?usp=sharing)
 - [GPT-3.5 Fine-tuning Notebook (Notebook link)](../examples/finetuning/openai_fine_tuning.ipynb)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -702,6 +702,7 @@ nav:
               - ./module_guides/querying/response_synthesizers/index.md
               - ./module_guides/querying/response_synthesizers/response_synthesizers.md
           - Routing: ./module_guides/querying/router/index.md
+          - Workflows: ./module_guides/querying/workflow/index.md
           - Query Pipelines:
               - ./module_guides/querying/pipeline/index.md
               - ./module_guides/querying/pipeline/usage_pattern.md

--- a/docs/prepare_for_build.py
+++ b/docs/prepare_for_build.py
@@ -52,6 +52,7 @@ FOLDER_NAME_TO_LABEL = {
     "./examples/transforms": "Transforms",
     "./examples/usecases": "Use Cases",
     "./examples/vector_stores": "Vector Stores",
+    "./examples/workflow": "Workflow",
 }
 
 # integration config

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import types
 from typing import (
     get_args,
     get_origin,
@@ -100,7 +101,7 @@ def _get_param_types(param: inspect.Parameter) -> List[object]:
     typ = param.annotation
     if typ is inspect.Parameter.empty:
         return [Any]
-    if get_origin(typ) in (Union, Optional):
+    if get_origin(typ) in (Union, Optional, types.UnionType):
         return [t for t in get_args(typ) if t is not type(None)]
     return [typ]
 
@@ -116,7 +117,7 @@ def _get_return_types(func: Callable) -> List[object]:
         return []
 
     origin = get_origin(return_hint)
-    if origin == Union:
+    if origin == Union or origin == types.UnionType:
         # Optional is Union[type, None] so it's covered here
         return [t for t in get_args(return_hint) if t is not type(None)]
     else:


### PR DESCRIPTION
This PR adds an initial docs page on workflows, and also makes a home for example notebooks.

I updated some spots that linked to or suggested using query pipelines, and switched to workflows.

I also updated some terminology throughout the docs, swapping "pipeline" with "workflow" or "flow" where it made sense (this is debatable, willing to undo this if not needed)

The meat of this change can be found in `docs/docs/examples/workflow` and `docs/docs/module_guides/workflow/index.md`