### PR TITLE
Simplify collection of multiple events from single steps

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List, Type
 
 from .events import Event
 
@@ -13,13 +13,19 @@ class Context:
 
         # Step-specific instance
         self.parent = parent
-        self._params_buffer: Dict[str, Any] = {}
+        self._events_buffer: Dict[Type[Event], Event] = {}
 
-    def collect_params(self, ev: Event, *params) -> Optional[Dict[str, Any]]:
-        for param in params:
-            if hasattr(ev, param):
-                self._params_buffer[param] = getattr(ev, param)
+    def collect_events(
+        self, ev: Event, expected: List[Type[Event]]
+    ) -> Optional[List[Event]]:
+        self._events_buffer[type(ev)] = ev
 
-        if list(self._params_buffer.keys()) == list(params):
-            return self._params_buffer
+        retval: List[Event] = []
+        for e_type in expected:
+            e_instance = self._events_buffer.get(e_type)
+            if e_instance:
+                retval.append(e_instance)
+
+        if len(retval) == len(expected):
+            return retval
         return None

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -1,4 +1,25 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
-# At this stage, Context is just a type alias for a dict with string keys.
-Context = Dict[str, Any]
+from .events import Event
+
+
+class Context:
+    def __init__(self, parent: Optional["Context"] = None) -> None:
+        # Global state
+        if parent:
+            self.data = parent.data
+        else:
+            self.data: Dict[str, Any] = {}
+
+        # Step-specific instance
+        self.parent = parent
+        self._params_buffer: Dict[str, Any] = {}
+
+    def collect_params(self, ev: Event, *params) -> Optional[Dict[str, Any]]:
+        for param in params:
+            if hasattr(ev, param):
+                self._params_buffer[param] = getattr(ev, param)
+
+        if list(self._params_buffer.keys()) == list(params):
+            return self._params_buffer
+        return None

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -57,6 +57,7 @@ def validate_step_signature(fn: Callable) -> Tuple[str, List[object], List[objec
 
         # Number of events in the signature must be exactly one
         num_of_possible_events += 1
+        event_name = name
 
     if num_of_possible_events != 1:
         msg = f"Step signature must contain exactly one parameter of type Event but found {num_of_possible_events}."

--- a/llama-index-core/tests/workflow/conftest.py
+++ b/llama-index-core/tests/workflow/conftest.py
@@ -3,14 +3,15 @@ import pytest
 from llama_index.core.workflow.workflow import Workflow
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import StartEvent, StopEvent, Event
+from llama_index.core.bridge.pydantic import Field
 
 
-class TestEvent(Event):
-    pass
+class OneTestEvent(Event):
+    test_param: str = Field(default="test")
 
 
 class AnotherTestEvent(Event):
-    pass
+    another_test_param: str = Field(default="another_test")
 
 
 class LastEvent(Event):
@@ -19,11 +20,11 @@ class LastEvent(Event):
 
 class DummyWorkflow(Workflow):
     @step()
-    async def start_step(self, ev: StartEvent) -> TestEvent:
-        return TestEvent()
+    async def start_step(self, ev: StartEvent) -> OneTestEvent:
+        return OneTestEvent()
 
     @step()
-    async def middle_step(self, ev: TestEvent) -> LastEvent:
+    async def middle_step(self, ev: OneTestEvent) -> LastEvent:
         return LastEvent()
 
     @step()
@@ -38,4 +39,4 @@ def workflow():
 
 @pytest.fixture()
 def events():
-    return [TestEvent, AnotherTestEvent]
+    return [OneTestEvent, AnotherTestEvent]

--- a/llama-index-core/tests/workflow/examples/rag.py
+++ b/llama-index-core/tests/workflow/examples/rag.py
@@ -42,7 +42,7 @@ class RAGWorkflow(Workflow):
             return None
 
         _, documents = download_llama_dataset(dsname, "./data")
-        ctx["INDEX"] = VectorStoreIndex.from_documents(documents=documents)
+        ctx.data["INDEX"] = VectorStoreIndex.from_documents(documents=documents)
         return StopEvent(result=f"Indexed {len(documents)} documents.")
 
     @step(pass_context=True)
@@ -53,7 +53,7 @@ class RAGWorkflow(Workflow):
 
         print(f"Query the database with: {query}")
 
-        index: Any = ctx.get("INDEX")
+        index: Any = ctx.data.get("INDEX")
         if index is None:
             print("Index is empty, load some documents before querying!")
             return None
@@ -71,11 +71,13 @@ class RAGWorkflow(Workflow):
         self, ctx: Context, ev: Union[RetrieverEvent, StartEvent]
     ) -> Optional[QueryResult]:
         if isinstance(ev, StartEvent):
-            ctx["QUERY"] = ev.get("query", "")
+            ctx.data["QUERY"] = ev.get("query", "")
             return None
         elif isinstance(ev, RetrieverEvent):
             ranker = LLMRerank(choice_batch_size=5, top_n=3)
-            new_nodes = ranker.postprocess_nodes(ev.nodes, query_str=ctx.get("QUERY"))
+            new_nodes = ranker.postprocess_nodes(
+                ev.nodes, query_str=ctx.data.get("QUERY")
+            )
             print(f"Reranked nodes to {len(new_nodes)}")
             return QueryResult(nodes=new_nodes)
         else:
@@ -88,12 +90,12 @@ async def synthesize(
 ) -> Optional[StopEvent]:
     # Should never fallback, it'll get better once we have a proper context storage
     if isinstance(ev, StartEvent):
-        ctx["QUERY"] = ev.get("query", "")
+        ctx.data["QUERY"] = ev.get("query", "")
         return None
     elif isinstance(ev, QueryResult):
         llm = Ollama(model="llama3.1:8b", request_timeout=120)
         summarizer = Refine(llm=llm, streaming=True, verbose=True)
-        query = ctx.get("QUERY", "")
+        query = ctx.data.get("QUERY", "")
         response = await summarizer.asynthesize(query, nodes=ev.nodes)
         return StopEvent(result=response)
     else:

--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -29,10 +29,10 @@ async def test_collect_events():
         async def step3(
             self, ctx: Context, ev: Union[OneTestEvent, AnotherTestEvent]
         ) -> Optional[StopEvent]:
-            params = ctx.collect_events(ev, [OneTestEvent, AnotherTestEvent])
-            if params is None:
+            events = ctx.collect_events(ev, [OneTestEvent, AnotherTestEvent])
+            if events is None:
                 return None
-            return StopEvent(result=params)
+            return StopEvent(result=events)
 
     workflow = TestWorkflow()
     result = await workflow.run()

--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -1,0 +1,36 @@
+import pytest
+from typing import Union, Optional
+
+from llama_index.core.workflow.workflow import (
+    Workflow,
+    Context,
+)
+from llama_index.core.workflow.decorators import step
+from llama_index.core.workflow.events import StartEvent, StopEvent
+
+from .conftest import OneTestEvent, AnotherTestEvent
+
+
+@pytest.mark.asyncio()
+async def test_collect_params():
+    class TestWorkflow(Workflow):
+        @step()
+        async def step1(self, _: StartEvent) -> OneTestEvent:
+            return OneTestEvent()
+
+        @step()
+        async def step2(self, _: StartEvent) -> AnotherTestEvent:
+            return AnotherTestEvent()
+
+        @step(pass_context=True)
+        async def step3(
+            self, ctx: Context, ev: Union[OneTestEvent, AnotherTestEvent]
+        ) -> Optional[StopEvent]:
+            params = ctx.collect_params(ev, "test_param", "another_test_param")
+            if params is None:
+                return None
+            return StopEvent(result=params)
+
+    workflow = TestWorkflow()
+    result = await workflow.run()
+    assert result == {"test_param": "test", "another_test_param": "another_test"}

--- a/llama-index-core/tests/workflow/test_utils.py
+++ b/llama-index-core/tests/workflow/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.errors import WorkflowValidationError
-from llama_index.core.workflow.events import Event, StartEvent, StopEvent
+from llama_index.core.workflow.events import StartEvent, StopEvent
 from llama_index.core.workflow.utils import (
     validate_step_signature,
     get_steps_from_class,
@@ -16,45 +16,39 @@ from llama_index.core.workflow.utils import (
 )
 from llama_index.core.workflow.context import Context
 
-
-class TestEvent(Event):
-    pass
-
-
-class AnotherTestEvent(Event):
-    pass
+from .conftest import OneTestEvent, AnotherTestEvent
 
 
 def test_validate_step_signature_of_method():
-    def f(self, ev: TestEvent) -> TestEvent:
-        return TestEvent()
+    def f(self, ev: OneTestEvent) -> OneTestEvent:
+        return OneTestEvent()
 
     validate_step_signature(f)
 
 
 def test_validate_step_signature_of_free_function():
-    def f(ev: TestEvent) -> TestEvent:
-        return TestEvent()
+    def f(ev: OneTestEvent) -> OneTestEvent:
+        return OneTestEvent()
 
     validate_step_signature(f)
 
 
 def test_validate_step_signature_union():
-    def f(ev: Union[TestEvent, AnotherTestEvent]) -> TestEvent:
-        return TestEvent()
+    def f(ev: Union[OneTestEvent, AnotherTestEvent]) -> OneTestEvent:
+        return OneTestEvent()
 
     validate_step_signature(f)
 
 
 def test_validate_step_signature_of_free_function_with_context():
-    def f(ctx: Context, ev: TestEvent) -> TestEvent:
-        return TestEvent()
+    def f(ctx: Context, ev: OneTestEvent) -> OneTestEvent:
+        return OneTestEvent()
 
     validate_step_signature(f)
 
 
 def test_validate_step_signature_union_invalid():
-    def f(ev: Union[TestEvent, str]) -> None:
+    def f(ev: Union[OneTestEvent, str]) -> None:
         pass
 
     with pytest.raises(
@@ -97,7 +91,7 @@ def test_validate_step_signature_wrong_annotations():
 
 
 def test_validate_step_signature_no_return_annotations():
-    def f(self, ev: TestEvent):
+    def f(self, ev: OneTestEvent):
         pass
 
     with pytest.raises(
@@ -119,10 +113,10 @@ def test_validate_step_signature_no_events():
 
 
 def test_validate_step_signature_too_many_params():
-    def f1(self, ev: TestEvent, foo: TestEvent) -> None:
+    def f1(self, ev: OneTestEvent, foo: OneTestEvent) -> None:
         pass
 
-    def f2(ev: TestEvent, foo: TestEvent):
+    def f2(ev: OneTestEvent, foo: OneTestEvent):
         pass
 
     with pytest.raises(
@@ -141,11 +135,11 @@ def test_validate_step_signature_too_many_params():
 def test_get_steps_from():
     class Test:
         @step()
-        def start(self, start: StartEvent) -> TestEvent:
-            return TestEvent()
+        def start(self, start: StartEvent) -> OneTestEvent:
+            return OneTestEvent()
 
         @step()
-        def my_method(self, event: TestEvent) -> StopEvent:
+        def my_method(self, event: OneTestEvent) -> StopEvent:
             return StopEvent()
 
         def not_a_step(self):

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -10,7 +10,7 @@ from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import StartEvent, StopEvent
 
 
-from .conftest import TestEvent
+from .conftest import OneTestEvent
 
 
 @pytest.mark.asyncio()
@@ -82,12 +82,12 @@ async def test_workflow_event_propagation():
 
     class EventTrackingWorkflow(Workflow):
         @step()
-        async def step1(self, ev: StartEvent) -> TestEvent:
+        async def step1(self, ev: StartEvent) -> OneTestEvent:
             events.append("step1")
-            return TestEvent()
+            return OneTestEvent()
 
         @step()
-        async def step2(self, ev: TestEvent) -> StopEvent:
+        async def step2(self, ev: OneTestEvent) -> StopEvent:
             events.append("step2")
             return StopEvent(result="Done")
 
@@ -100,11 +100,11 @@ async def test_workflow_event_propagation():
 async def test_sync_async_steps():
     class SyncAsyncWorkflow(Workflow):
         @step()
-        async def async_step(self, ev: StartEvent) -> TestEvent:
-            return TestEvent()
+        async def async_step(self, ev: StartEvent) -> OneTestEvent:
+            return OneTestEvent()
 
         @step()
-        def sync_step(self, ev: TestEvent) -> StopEvent:
+        def sync_step(self, ev: OneTestEvent) -> StopEvent:
             return StopEvent(result="Done")
 
     workflow = SyncAsyncWorkflow()


### PR DESCRIPTION
# Description

The main goal of this PR is providing an utility method to simplify how to manage multiple events received by a single step. 

Before (it could be done slightly better but let's look at the naive approach):
```py
@step(pass_context=True)
async def step(self, ctx: Context, ev: Union[OneTestEvent, AnotherTestEvent]) -> Optional[StopEvent]:
    if isinstance(ev, OneTestEvent) and not "OneTestEvent" in ctx.data:
        ctx.data["OneTestEvent"] = ev
    
    if isinstance(ev, AnotherTestEvent) not "AnotherTestEvent" in ctx.data:
        ctx.data["AnotherTestEvent"] = ev
    
    if "OneTestEvent" in ctx.data and "AnotherTestEvent" in ctx.data:
        # do something with the two events
    else:
        return None    
```

After this PR:
```py
@step(pass_context=True)
async def step(self, ctx: Context, ev: Union[OneTestEvent, AnotherTestEvent]) -> Optional[StopEvent]:
    events = ctx.collect_events(ev, [OneTestEvent, AnotherTestEvent])
    if events is None:
        return None
    # do something with the two events
```

